### PR TITLE
fix: remove forced password-change gate after provisioning/reset

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -81,7 +81,6 @@ def create_app() -> Flask:
                 username=login_id,
                 role="admin",
                 credential_source="admin_provisioned",
-                must_change_password=True,
                 is_active=True,
             )
             admin.set_password(password)

--- a/backend/app/auth/routes.py
+++ b/backend/app/auth/routes.py
@@ -249,7 +249,6 @@ def reset_password():
 
     temp_password = _generate_temp_password()
     user.set_password(temp_password)
-    user.must_change_password = True
     db.session.commit()
 
     try:
@@ -349,7 +348,6 @@ def provision_credentials():
         role=target_role,
         username=username or None,
         credential_source="admin_provisioned",
-        must_change_password=True,
     )
     user.set_password(temp_password)
     db.session.add(user)
@@ -454,7 +452,6 @@ def provision_bulk_credentials():
             role=target_role,
             username=username or None,
             credential_source="admin_provisioned",
-            must_change_password=True,
         )
         user.set_password(temp_password)
         db.session.add(user)

--- a/backend/app/exams/routes.py
+++ b/backend/app/exams/routes.py
@@ -9,11 +9,6 @@ from app.models import BehavioralLog, Exam, ExamSession, Question, Report, Sessi
 exams_bp = Blueprint("exams", __name__)
 
 
-def _password_change_required(user_id: int) -> bool:
-    user = db.session.get(User, user_id)
-    return bool(user and user.must_change_password)
-
-
 def _lecturer_profile_confirmed(user_id: int) -> bool:
     user = db.session.get(User, user_id)
     return bool(user and user.role == "lecturer" and user.lecturer_profile_confirmed)
@@ -78,8 +73,6 @@ def create_exam():
     user_id = int(get_jwt_identity())
     if role not in {"lecturer", "admin"}:
         return jsonify({"error": {"message": "Forbidden"}}), 403
-    if _password_change_required(user_id):
-        return jsonify({"error": {"message": "Password change required before exam management"}}), 403
     if role == "lecturer" and not _lecturer_profile_confirmed(user_id):
         return jsonify({"error": {"message": "Complete and confirm your lecturer profile before managing exams."}}), 403
 
@@ -120,8 +113,6 @@ def update_exam_status(exam_id):
     user_id = int(get_jwt_identity())
     if role not in {"lecturer", "admin"}:
         return jsonify({"error": {"message": "Forbidden"}}), 403
-    if _password_change_required(user_id):
-        return jsonify({"error": {"message": "Password change required before exam management"}}), 403
     if role == "lecturer" and not _lecturer_profile_confirmed(user_id):
         return jsonify({"error": {"message": "Complete and confirm your lecturer profile before managing exams."}}), 403
 
@@ -151,8 +142,6 @@ def update_exam(exam_id):
     user_id = int(get_jwt_identity())
     if role not in {"lecturer", "admin"}:
         return jsonify({"error": {"message": "Forbidden"}}), 403
-    if _password_change_required(user_id):
-        return jsonify({"error": {"message": "Password change required before exam management"}}), 403
     if role == "lecturer" and not _lecturer_profile_confirmed(user_id):
         return jsonify({"error": {"message": "Complete and confirm your lecturer profile before managing exams."}}), 403
 
@@ -194,8 +183,6 @@ def delete_exam(exam_id):
     user_id = int(get_jwt_identity())
     if role not in {"lecturer", "admin"}:
         return jsonify({"error": {"message": "Forbidden"}}), 403
-    if _password_change_required(user_id):
-        return jsonify({"error": {"message": "Password change required before exam management"}}), 403
     if role == "lecturer" and not _lecturer_profile_confirmed(user_id):
         return jsonify({"error": {"message": "Complete and confirm your lecturer profile before managing exams."}}), 403
 
@@ -270,8 +257,6 @@ def create_question(exam_id):
     user_id = int(get_jwt_identity())
     if role not in {"lecturer", "admin"}:
         return jsonify({"error": {"message": "Forbidden"}}), 403
-    if _password_change_required(user_id):
-        return jsonify({"error": {"message": "Password change required before exam management"}}), 403
     if role == "lecturer" and not _lecturer_profile_confirmed(user_id):
         return jsonify({"error": {"message": "Complete and confirm your lecturer profile before managing exams."}}), 403
 
@@ -317,8 +302,6 @@ def delete_question(exam_id, question_id):
     user_id = int(get_jwt_identity())
     if role not in {"lecturer", "admin"}:
         return jsonify({"error": {"message": "Forbidden"}}), 403
-    if _password_change_required(user_id):
-        return jsonify({"error": {"message": "Password change required before exam management"}}), 403
     if role == "lecturer" and not _lecturer_profile_confirmed(user_id):
         return jsonify({"error": {"message": "Complete and confirm your lecturer profile before managing exams."}}), 403
 
@@ -343,8 +326,6 @@ def update_question(exam_id, question_id):
     user_id = int(get_jwt_identity())
     if role not in {"lecturer", "admin"}:
         return jsonify({"error": {"message": "Forbidden"}}), 403
-    if _password_change_required(user_id):
-        return jsonify({"error": {"message": "Password change required before exam management"}}), 403
     if role == "lecturer" and not _lecturer_profile_confirmed(user_id):
         return jsonify({"error": {"message": "Complete and confirm your lecturer profile before managing exams."}}), 403
 

--- a/backend/app/sessions/routes.py
+++ b/backend/app/sessions/routes.py
@@ -13,11 +13,6 @@ sessions_bp = Blueprint("sessions", __name__)
 VALID_EVENTS = {"gaze_away", "head_turned", "face_absent", "tab_switch", "multiple_faces"}
 
 
-def _password_change_required(user_id: int) -> bool:
-    user = db.session.get(User, user_id)
-    return bool(user and user.must_change_password)
-
-
 def _student_profile_ready_for_verification(user: User) -> tuple[bool, str]:
     if not user:
         return False, "User not found"
@@ -70,8 +65,6 @@ def start_session():
     ready, message = _student_profile_ready_for_verification(student)
     if not ready:
         return jsonify({"error": {"message": message}}), 409
-    if _password_change_required(student_id):
-        return jsonify({"error": {"message": "Password change required before exam start"}}), 403
     existing = ExamSession.query.filter_by(student_id=student_id, exam_id=exam.exam_id).first()
     if existing:
         if existing.session_status in {"active", "pending"} and not existing.submitted_at:

--- a/backend/app/users/routes.py
+++ b/backend/app/users/routes.py
@@ -29,11 +29,6 @@ def _generate_temp_password(length=12):
     return "".join(random.choice(alphabet) for _ in range(length))
 
 
-def _password_change_required(user_id: int) -> bool:
-    user = db.session.get(User, user_id)
-    return bool(user and user.must_change_password)
-
-
 def _delete_exam_cascade(exam_id: int) -> None:
     session_ids = [
         row[0]
@@ -204,8 +199,6 @@ def update_profile():
 def list_users():
     if not _is_admin():
         return jsonify({"error": {"message": "Forbidden"}}), 403
-    if _password_change_required(int(get_jwt_identity())):
-        return jsonify({"error": {"message": "Password change required before admin actions"}}), 403
 
     role = (request.args.get("role") or "").strip().lower()
     query = (request.args.get("query") or "").strip().lower()
@@ -235,8 +228,6 @@ def update_user_status(user_id: int):
     if not _is_admin():
         return jsonify({"error": {"message": "Forbidden"}}), 403
     actor_user_id = int(get_jwt_identity())
-    if _password_change_required(actor_user_id):
-        return jsonify({"error": {"message": "Password change required before admin actions"}}), 403
 
     user = db.session.get(User, user_id)
     if not user:
@@ -266,8 +257,6 @@ def delete_user(user_id: int):
     if not _is_admin():
         return jsonify({"error": {"message": "Forbidden"}}), 403
     actor_user_id = int(get_jwt_identity())
-    if _password_change_required(actor_user_id):
-        return jsonify({"error": {"message": "Password change required before admin actions"}}), 403
     if actor_user_id == user_id:
         return jsonify({"error": {"message": "You cannot delete your own account"}}), 400
 
@@ -326,8 +315,6 @@ def reset_credentials(user_id: int):
     if not _is_admin():
         return jsonify({"error": {"message": "Forbidden"}}), 403
     actor_user_id = int(get_jwt_identity())
-    if _password_change_required(actor_user_id):
-        return jsonify({"error": {"message": "Password change required before admin actions"}}), 403
 
     user = db.session.get(User, user_id)
     if not user:
@@ -337,7 +324,6 @@ def reset_credentials(user_id: int):
 
     temp_password = _generate_temp_password()
     user.set_password(temp_password)
-    user.must_change_password = True
     log_audit(
         action="admin.user_credentials_reset",
         actor_user_id=actor_user_id,
@@ -361,8 +347,6 @@ def reset_credentials(user_id: int):
 def list_audit_logs():
     if not _is_admin():
         return jsonify({"error": {"message": "Forbidden"}}), 403
-    if _password_change_required(int(get_jwt_identity())):
-        return jsonify({"error": {"message": "Password change required before admin actions"}}), 403
 
     action_filter = (request.args.get("action") or "").strip().lower()
     query_text = (request.args.get("query") or "").strip().lower()

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -90,7 +90,7 @@ def test_admin_provisions_instructor_credentials(client):
     body = provision.get_json()
     assert body["temporary_password"]
     assert body["login_id"] == "lecturer.jane"
-    assert body["user"]["must_change_password"] is True
+    assert body["user"]["must_change_password"] is False
 
     lecturer_login = client.post(
         "/api/auth/login",


### PR DESCRIPTION
## Summary
- Removes the `must_change_password=True` assignment from bootstrap admin creation, `provision-credentials`, `provision-bulk`, and `reset-password`.
- Removes the corresponding `_password_change_required()` gate (403 "Password change required before ...") from `exams/routes.py` (7 call sites), `sessions/routes.py` (1), and `users/routes.py` (5).
- Voluntary password change (`PUT /api/auth/change-password`) is untouched and still works.
- The `must_change_password` column/model field is intentionally left in place (unused going forward) rather than dropped via migration, to avoid an unnecessary schema change for a behavior-only removal.

## Context
This was requested to simplify manual E2E testing — admin/lecturer/student accounts no longer get blocked from normal actions pending a forced password change after being freshly provisioned.

## Test plan
- [x] Backend test suite passes locally (12/12), including an updated assertion in `test_auth.py` that provisioned accounts now get `must_change_password: False`
- [ ] Post-merge: provision a fresh lecturer + student via `/api/auth/provision-credentials` and confirm no 403 on exam creation / session start