### PR TITLE
feat: add exam publish button and baseline upload progress bar

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -105,6 +105,7 @@ function StudentDashboardInner() {
   const [academicYear, setAcademicYear] = useState("")
   const [yearEnrolled, setYearEnrolled] = useState("")
   const [uploadingImage, setUploadingImage] = useState(false)
+  const [uploadProgress, setUploadProgress] = useState<number | null>(null)
   const [currentPassword, setCurrentPassword] = useState("")
   const [newPassword, setNewPassword] = useState("")
   const [showCurrentPassword, setShowCurrentPassword] = useState(false)
@@ -278,24 +279,44 @@ function StudentDashboardInner() {
   async function uploadBaselineImage(file: File | null) {
     if (!file) return
     setUploadingImage(true)
+    setUploadProgress(0)
     setProfileMsg("")
     try {
       const body = new FormData()
       body.append("image", file)
-      const res = await fetch(getApiPath("/images/me"), {
-        method: "POST",
-        headers: { Authorization: `Bearer ${token}` },
-        body,
+
+      const result = await new Promise<{ ok: boolean; payload: any }>((resolve, reject) => {
+        const xhr = new XMLHttpRequest()
+        xhr.open("POST", getApiPath("/images/me"))
+        xhr.setRequestHeader("Authorization", `Bearer ${token}`)
+        xhr.upload.onprogress = (e) => {
+          if (e.lengthComputable) setUploadProgress(Math.round((e.loaded / e.total) * 100))
+        }
+        xhr.onload = () => {
+          let payload: any = {}
+          try {
+            payload = JSON.parse(xhr.responseText)
+          } catch {
+            payload = {}
+          }
+          resolve({ ok: xhr.status >= 200 && xhr.status < 300, payload })
+        }
+        xhr.onerror = () => reject(new Error("Network error during upload"))
+        xhr.send(body)
       })
-      const payload = await res.json().catch(() => ({}))
-      if (!res.ok) {
-        setProfileMsg(payload?.error?.message || "Could not upload image.")
+
+      if (!result.ok) {
+        setProfileMsg(result.payload?.error?.message || "Could not upload image.")
         return
       }
+      setUploadProgress(100)
       setProfileMsg("Baseline face image uploaded successfully.")
       await loadBaselineImage(token)
+    } catch {
+      setProfileMsg("Could not upload image.")
     } finally {
       setUploadingImage(false)
+      setTimeout(() => setUploadProgress(null), 1000)
     }
   }
 
@@ -608,6 +629,17 @@ function StudentDashboardInner() {
                   {uploadingImage ? "Uploading..." : baselineImageUrl ? "Replace Image" : "Upload Image"}
                   <input type="file" accept="image/jpeg,image/png" className="hidden" onChange={(e) => void uploadBaselineImage(e.target.files?.[0] ?? null)} />
                 </label>
+                {uploadProgress !== null ? (
+                  <div className="w-48">
+                    <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+                      <div
+                        className="h-full rounded-full bg-[#1a2d5a] transition-all duration-150"
+                        style={{ width: `${uploadProgress}%` }}
+                      />
+                    </div>
+                    <p className="mt-1 text-xs text-muted-foreground">{uploadProgress}%</p>
+                  </div>
+                ) : null}
               </div>
             </div>
           </DashboardPanel>
@@ -656,9 +688,20 @@ function StudentDashboardInner() {
             <input value={yearEnrolled} onChange={e => setYearEnrolled(e.target.value)} placeholder="Year enrolled (e.g. 2024)" className="rounded-md border border-border bg-background p-2 text-sm text-foreground" />
             <div className="md:col-span-2">
               <label className="inline-flex cursor-pointer items-center gap-2 rounded-md border border-border bg-background px-3 py-2 text-sm font-medium text-foreground">
-                Upload Baseline Photo
+                {uploadingImage ? "Uploading..." : "Upload Baseline Photo"}
                 <input type="file" accept="image/jpeg,image/png" className="hidden" onChange={(e) => void uploadBaselineImage(e.target.files?.[0] ?? null)} />
               </label>
+              {uploadProgress !== null ? (
+                <div className="mt-2 w-48">
+                  <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+                    <div
+                      className="h-full rounded-full bg-[#1a2d5a] transition-all duration-150"
+                      style={{ width: `${uploadProgress}%` }}
+                    />
+                  </div>
+                  <p className="mt-1 text-xs text-muted-foreground">{uploadProgress}%</p>
+                </div>
+              ) : null}
               <p className="mt-1 text-xs text-muted-foreground">
                 Baseline status: {baselineImageUrl ? "Uploaded" : "Not uploaded"}
               </p>

--- a/frontend/app/lecturer/page.tsx
+++ b/frontend/app/lecturer/page.tsx
@@ -766,9 +766,32 @@ function LecturerDashboardInner() {
             {questionType === "mcq" && <input value={optionD} onChange={e => setOptionD(e.target.value)} placeholder="Option D" className="rounded-md border border-border bg-background p-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-[#1a2d5a] focus:outline-none focus:ring-2 focus:ring-blue-100" />}
             <input value={correctAnswer} onChange={e => setCorrectAnswer(e.target.value)} placeholder="Correct answer (e.g. A or TRUE)" className="rounded-md border border-border bg-background p-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-[#1a2d5a] focus:outline-none focus:ring-2 focus:ring-blue-100 md:col-span-2" />
           </div>
-          <button onClick={createQuestion} disabled={!selectedExamId} className="mt-3 rounded-md bg-[#1a2d5a] px-4 py-2 text-sm font-semibold text-white transition hover:bg-[#142145] disabled:opacity-60">
-            Add Question
-          </button>
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <button onClick={createQuestion} disabled={!selectedExamId} className="rounded-md bg-[#1a2d5a] px-4 py-2 text-sm font-semibold text-white transition hover:bg-[#142145] disabled:opacity-60">
+              Add Question
+            </button>
+            {selectedExam && selectedExam.status !== "live" && selectedExam.status !== "completed" && (
+              <button
+                onClick={async () => {
+                  const ok = window.confirm(
+                    `Publish "${selectedExam.title}" to students now? They will be able to start the exam immediately.`
+                  )
+                  if (!ok) return
+                  await updateExamStatus(selectedExam.exam_id, "live")
+                }}
+                disabled={questions.length === 0}
+                title={questions.length === 0 ? "Add at least one question before publishing" : undefined}
+                className="rounded-md border border-green-600 bg-green-50 px-4 py-2 text-sm font-semibold text-green-700 transition hover:bg-green-100 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Publish Exam to Students
+              </button>
+            )}
+            {selectedExam && selectedExam.status === "live" && (
+              <span className="rounded-full border border-green-600 bg-green-50 px-3 py-1 text-xs font-medium text-green-700">
+                Published — live for students
+              </span>
+            )}
+          </div>
 
           <div className="mt-4 overflow-x-auto">
             <table className="w-full text-sm">


### PR DESCRIPTION
## Summary
- **Lecturer flow**: after adding at least one question on the Question Builder page, a "Publish Exam to Students" button appears (with a confirm prompt) that sets the exam status to `live` directly — no more going back to the Exams tab to change the status dropdown manually. A "Published — live for students" badge shows once live.
- **Student flow**: baseline image upload now shows a real-time progress bar. Switched from `fetch` to `XMLHttpRequest` since the Fetch API has no upload-progress event.

## Test plan
- [x] `tsc --noEmit` passes with zero errors
- [x] Manually verified in a real browser against production (via local dev server pointed at `https://proctoaibackend.neuraltale.com`): created a test exam as `mohamed.dewa`, added a question, confirmed the Publish button appeared only after a question existed, clicked it, and confirmed via API that the exam's status flipped to `live`. Test exam/question cleaned up afterward.
- [x] Manually verified the upload progress bar as `T22-03-11759`: captured it live at 74% mid-upload, confirmed it reaches completion and shows the success message.