### PR TITLE
docs: reflect gaze model, password-change removal, and Vercel deploy split

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,8 @@ docker-compose up          # starts frontend, backend, ai-service, postgres
 - **Frontend stack**: Next.js 15, React 19, TypeScript, Tailwind CSS, shadcn/ui, Recharts
 - **Backend stack**: Python Flask, PostgreSQL, SQLAlchemy, JWT, bcrypt, Nodemailer equiv (smtplib)
 - **AI service**: Python Flask + ONNX Runtime + MediaPipe + OpenCV + Socket.io
+- **Deployment split**: the frontend (`frontend/`) is hosted on **Vercel**, which auto-deploys on every push to `main` via its own GitHub integration — this is completely separate from `.github/workflows/cd.yml`, which only deploys `backend` + `ai-service` to the VPS. There is no frontend container on the VPS. Don't assume merging a frontend-only PR needs a manual VPS deploy step — it doesn't.
+- **Password policy**: there is no forced password-change-on-first-login anymore (removed 2026-07-02) — provisioned/reset accounts are immediately usable with their temporary password. `must_change_password` still exists as a DB column but nothing sets it `True` or enforces it.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ An AI-powered exam proctoring platform that verifies student identity via facial
 [![CI](https://github.com/victorjudysen/ai-exam-proctoring-system/actions/workflows/ci.yml/badge.svg)](https://github.com/victorjudysen/ai-exam-proctoring-system/actions/workflows/ci.yml)
 [![CD](https://github.com/victorjudysen/ai-exam-proctoring-system/actions/workflows/cd.yml/badge.svg)](https://github.com/victorjudysen/ai-exam-proctoring-system/actions/workflows/cd.yml)
 
+**Production:** [proctoai.neuraltale.com](https://proctoai.neuraltale.com) (frontend, hosted on Vercel) · [proctoaibackend.neuraltale.com](https://proctoaibackend.neuraltale.com) (backend + AI service, VPS)
+
 ---
 
 ## Tech Stack
@@ -48,12 +50,14 @@ docker compose up
 npm install
 npm test
 
-# Backend unit tests
-cd backend && npm ci && npm test
+# Backend unit tests (Flask + pytest)
+cd backend && pip install -r requirements.txt && python -m pytest tests/ -v
 
 # AI service tests
 cd ai-service && pip install -r requirements.txt && python -m pytest tests/ -v
 ```
+
+Note: model-loading tests in `ai-service/tests/` (e.g. gaze model file existence/inference) skip automatically when `*.onnx` files aren't present — those binaries are gitignored and only exist where manually placed (a dev machine or the VPS), never in CI.
 
 ---
 
@@ -61,11 +65,13 @@ cd ai-service && pip install -r requirements.txt && python -m pytest tests/ -v
 
 **CI** triggers on every push to any branch and on pull requests to `main`. It runs all tests, then builds the Docker images. The build job will not start if any test fails.
 
-**CD** deploys the API stack automatically after CI passes on `main`. It can also be started manually from GitHub Actions with `workflow_dispatch`.
+**CD** (`cd.yml`) deploys the **backend + AI service only** — it does not touch the frontend. It runs automatically after CI passes on `main`, and can also be started manually from GitHub Actions with `workflow_dispatch`.
 
 | Step | What happens |
 |------|-------------|
-| `deploy-production` | SSHs into the VPS, fast-forwards `/opt/proctorai/ai-exam-proctoring-system`, validates required model files, rebuilds backend/AI images, runs Alembic migrations, restarts only ProctorAI services, and checks public health endpoints |
+| `deploy-production` | SSHs into the VPS, fast-forwards `/opt/proctorai/ai-exam-proctoring-system`, validates required model files (`facenet_best.onnx`, `gaze_model.onnx`), rebuilds backend/AI images via `docker-compose.api-prod.yml`, runs Alembic migrations, restarts only ProctorAI services, and checks public health endpoints |
+
+**The frontend deploys separately and automatically via Vercel's own GitHub integration** — every push to `main` triggers a Vercel production deployment of `frontend/`, independent of `cd.yml` and the VPS entirely. There is no frontend container on the VPS; check deployment status via GitHub → the commit's checks, or `gh api repos/<owner>/<repo>/deployments`.
 
 ### GitHub Secrets required
 
@@ -97,7 +103,8 @@ git clone https://github.com/victorjudysen/ai-exam-proctoring-system.git /opt/pr
 cd /opt/proctorai/ai-exam-proctoring-system
 cp .env.production.example .env.production
 
-# 4. Upload AI model files to ai-service/models/
+# 4. Upload AI model files to ai-service/models/ (gitignored, not shipped by git pull/CD — copy manually via scp/rsync)
+#    Required: facenet_best.onnx, facenet_best.onnx.data, gaze_model.onnx
 ls -lh ai-service/models/
 
 # 5. Ensure Docker and Docker Compose are installed
@@ -112,7 +119,7 @@ docker compose version
 ```
 ai-exam-proctoring-system/
 ├── frontend/          Next.js app
-├── backend/           Express REST API
+├── backend/           Flask REST API
 ├── ai-service/        Flask AI endpoints (WebSocket + model inference)
 ├── tests/             Root-level integration tests (Jest + Supertest)
 ├── docs/              API spec, test cases, SRS

--- a/docs/PROJECT_MEMORY_TODO.md
+++ b/docs/PROJECT_MEMORY_TODO.md
@@ -1,7 +1,16 @@
 # Project Memory TODO
 
-Last updated: 2026-05-11
-Source: recent implementation + pushes to `main` (`3fa9807` .. `ecab61d`)
+Last updated: 2026-07-02
+Source: recent implementation + pushes to `main` (PR #92 .. #94)
+
+## Session Checkpoint (2026-07-02)
+
+- [x] Gaze model integration: replaced non-functional `l2cs_net.onnx` (output tensor name mismatch meant it silently never worked) with `gaze_model.onnx`, a custom CNN trained on MPIIGaze-normalized eye crops. Added `detect_and_crop_eye()` (MediaPipe FaceMesh, roll-corrected) and matching preprocessing. Model path configurable via `GAZE_MODEL_VERSION`. Note: live eye-crop only corrects in-plane roll, not full MPIIGaze virtual-camera reprojection — a known accuracy gap, not yet addressed.
+- [x] Removed the forced password-change-on-first-login gate entirely (backend `_password_change_required()` checks removed from exams/sessions/users routes; bootstrap admin, `provision-credentials`, `provision-bulk`, and `reset-password` no longer set `must_change_password=True`). Simplifies E2E testing — provisioned accounts are immediately usable.
+- [x] Fresh production database: all prior users/exams/sessions truncated and a full team account set re-provisioned (1 admin via bootstrap env vars, 5 students, 5 lecturers) via `POST /api/auth/provision-bulk`.
+- [x] Lecturer Question Builder: added a "Publish Exam to Students" button (shows once ≥1 question exists) that sets exam status to `live` directly, instead of requiring a trip back to the Exams tab.
+- [x] Student baseline image upload: switched from `fetch` to `XMLHttpRequest` to show a real upload progress bar (Fetch has no upload-progress event).
+- [x] **Deployment topology clarified**: the frontend is hosted on Vercel with its own GitHub integration (auto-deploys on every push to `main`), entirely separate from `cd.yml`, which only deploys `backend` + `ai-service` to the VPS. There is no frontend container on the VPS. This wasn't documented anywhere before and caused confusion mid-session — now reflected in the root `README.md`.
 
 ## Session Checkpoint (2026-05-11)
 
@@ -59,7 +68,7 @@ Source: recent implementation + pushes to `main` (`3fa9807` .. `ecab61d`)
 ## Immediate Open Items
 
 - [ ] Run full live E2E dry run on VPS with current `main`:
-  - admin create student/lecturer -> first-login password change -> session start/verify/log/submit -> report export.
+  - admin create student/lecturer -> login (no forced password change, removed 2026-07-02) -> session start/verify/log/submit -> report export.
 - [ ] Validate `docker compose run --rm backend alembic upgrade head` behavior in production deploy logs.
 - [ ] Confirm live socket anomaly path (`anomaly_result`/`session_locked`) with real browser session evidence.
 - [ ] Remove/retire obsolete Node backend artifacts (`backend/server.js`, old `package.json` usage) once no longer needed.


### PR DESCRIPTION
## Summary
Documentation-only PR capturing everything learned/changed in this session that wasn't already reflected in the docs:

- **README.md**: fixed stale "Express REST API" label and backend test command (it's Flask/pytest, not npm), documented that `cd.yml` only deploys backend+ai-service while the frontend auto-deploys via Vercel's own GitHub integration (a fact that wasn't documented anywhere and caused real confusion mid-session), noted required model filenames for VPS setup, added production URLs.
- **CLAUDE.md**: added the Vercel/VPS deployment split and the forced-password-change removal to Key Design Decisions.
- **docs/PROJECT_MEMORY_TODO.md**: added a dated session checkpoint (gaze model swap, password-change gate removal, fresh account provisioning, exam publish button, upload progress bar, Vercel deployment finding) and fixed a stale checklist item that still referenced "first-login password change".

No code changes.