### PR TITLE
Increase monitoring frame cadence

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -46,11 +46,16 @@ On the sign-up page, face registration uses real browser camera access:
 
 Make sure your browser has camera permission enabled for `http://localhost:3000`.
 
+## Monitoring Cadence
+
+Live exam monitoring emits webcam frames every 1000ms by default. Set
+`NEXT_PUBLIC_MONITORING_FRAME_INTERVAL_MS` to a value between `500` and `1000`
+to tune the cadence for local testing or deployment.
+
 ## Learn More
 
 To learn more, take a look at the following resources:
 
 - [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
 - [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
 

--- a/frontend/app/exam/page.tsx
+++ b/frontend/app/exam/page.tsx
@@ -37,6 +37,20 @@ type ManualWarningEvent = {
   message?: string
 }
 
+const MIN_MONITORING_FRAME_INTERVAL_MS = 500
+const MAX_MONITORING_FRAME_INTERVAL_MS = 1000
+const DEFAULT_MONITORING_FRAME_INTERVAL_MS = 1000
+
+function getMonitoringFrameIntervalMs() {
+  const configuredInterval = Number(process.env.NEXT_PUBLIC_MONITORING_FRAME_INTERVAL_MS)
+  if (!Number.isFinite(configuredInterval)) return DEFAULT_MONITORING_FRAME_INTERVAL_MS
+
+  return Math.min(
+    MAX_MONITORING_FRAME_INTERVAL_MS,
+    Math.max(MIN_MONITORING_FRAME_INTERVAL_MS, configuredInterval),
+  )
+}
+
 export default function ExamPage() {
   const router = useRouter()
   const examCaptureVideoRef = useRef<HTMLVideoElement>(null)
@@ -598,7 +612,7 @@ export default function ExamPage() {
             frame_base64: frameBase64,
             timestamp: new Date().toISOString(),
           })
-        }, 2000)
+        }, getMonitoringFrameIntervalMs())
       } catch {
         setSocketConnected(false)
       }


### PR DESCRIPTION
## Summary

- Changes live exam webcam frame emission from a hard-coded 2000ms interval to a configurable 500-1000ms cadence.
- Defaults monitoring frames to 1000ms to provide denser signal without requiring deployment config.
- Documents NEXT_PUBLIC_MONITORING_FRAME_INTERVAL_MS in the frontend README.

## Why

Closes #105. The audit found that sparse 2-second sampling makes the gaze classifier feel unstable and gives the proctoring logic too little temporal evidence.

## Validation

- npm run lint from frontend/ passes with existing hook dependency warnings and no errors.