### PR TITLE
Use rolling window anomaly smoothing

### DIFF
--- a/ai-service/sockets/frame_handler.py
+++ b/ai-service/sockets/frame_handler.py
@@ -2,6 +2,7 @@ import threading
 import requests
 import os
 import time
+from collections import Counter
 
 from flask_socketio import SocketIO, emit, join_room
 
@@ -50,6 +51,7 @@ _ANOMALY_SECONDS = {
     'face_absent': float(os.getenv('FACE_ABSENT_SECONDS', os.getenv('GAZE_AWAY_SECONDS', '2'))),
     'multiple_faces': float(os.getenv('MULTIPLE_FACES_SECONDS', '2')),
 }
+_ANOMALY_MIN_OBSERVATIONS = int(os.getenv('ANOMALY_ROLLING_MIN_OBSERVATIONS', '2'))
 # Gap required between two CONFIRMED logs of the same continuously-sustained
 # anomaly. This is the real strictness bottleneck for a student who never
 # breaks the violation at all (e.g. stares away continuously): the 2s
@@ -112,37 +114,54 @@ def _calibrated_head_alert(session_id, pose):
         return alert, False
 
 
-def _confirmed_anomalies(session_id, current_anomalies):
-    """Return anomalies that have persisted long enough to count as warnings.
+def _representative_anomaly(observations):
+    qualified = [anomaly for _, anomaly in observations if ':' in anomaly]
+    if not qualified:
+        return observations[-1][1]
+    return Counter(qualified).most_common(1)[0][0]
 
-    Anomaly keys may be direction-qualified (e.g. 'gaze_away:Right') so that
-    the required persistence must be the SAME specific direction the whole
-    time — flip-flopping between different wrong directions (a signature of
-    model noise, not real gaze deviation) resets the timer instead of
-    accumulating toward a warning.
+
+def _confirmed_anomalies(session_id, current_anomalies):
+    """Return anomalies with enough rolling-window evidence to count.
+
+    Gaze predictions can jitter between non-Screen directions even when the
+    underlying signal is consistently suspicious. Track recent evidence by
+    base anomaly type instead of requiring the exact same direction to remain
+    uninterrupted for the whole persistence window.
     """
     now = time.monotonic()
-    current = set(current_anomalies)
+    current = list(dict.fromkeys(current_anomalies))
 
     with _lock:
         session_state = _anomaly_states.setdefault(session_id, {})
 
-        for anomaly in list(session_state):
-            if anomaly not in current:
-                del session_state[anomaly]
+        for anomaly_type, state in list(session_state.items()):
+            required_seconds = _ANOMALY_SECONDS.get(anomaly_type, 3.0)
+            state['observations'] = [
+                observation
+                for observation in state['observations']
+                if now - observation[0] <= required_seconds
+            ]
+            if not state['observations'] and anomaly_type not in {_base_type(a) for a in current}:
+                del session_state[anomaly_type]
 
         confirmed = []
         for anomaly in current:
+            anomaly_type = _base_type(anomaly)
             state = session_state.setdefault(
-                anomaly,
-                {'started_at': now, 'last_logged_at': 0.0},
+                anomaly_type,
+                {'observations': [], 'last_logged_at': -_WARNING_COOLDOWN_SECONDS},
             )
-            required_seconds = _ANOMALY_SECONDS.get(_base_type(anomaly), 3.0)
-            persisted = now - state['started_at']
+            state['observations'].append((now, anomaly))
+
+            required_seconds = _ANOMALY_SECONDS.get(anomaly_type, 3.0)
+            observations = state['observations']
+            persisted = now - observations[0][0] if observations else 0.0
             cooled_down = now - state['last_logged_at']
-            if persisted >= required_seconds and cooled_down >= _WARNING_COOLDOWN_SECONDS:
+            enough_observations = len(observations) >= _ANOMALY_MIN_OBSERVATIONS
+            if persisted >= required_seconds and enough_observations and cooled_down >= _WARNING_COOLDOWN_SECONDS:
                 state['last_logged_at'] = now
-                confirmed.append(anomaly)
+                confirmed.append(_representative_anomaly(observations))
 
     return confirmed
 

--- a/ai-service/tests/test_frame_handler_debounce.py
+++ b/ai-service/tests/test_frame_handler_debounce.py
@@ -24,31 +24,51 @@ def test_base_type_strips_direction_qualifier():
     assert fh._base_type('head_turned') == 'head_turned'
 
 
-def test_direction_change_resets_persistence(monkeypatch):
-    """Flip-flopping between different wrong directions must not accumulate
-    toward a confirmed warning — only a SUSTAINED single direction should."""
+def test_direction_changes_accumulate_in_rolling_gaze_window(monkeypatch):
+    """Flip-flopping between wrong gaze directions is still suspicious when
+    the rolling gaze-away window stays populated long enough."""
     _reset_state()
     times = iter([0.0, 1.0, 2.0])
     monkeypatch.setattr(fh.time, 'monotonic', lambda: next(times))
 
     assert fh._confirmed_anomalies('s1', ['gaze_away:Right']) == []
     assert fh._confirmed_anomalies('s1', ['gaze_away:Down']) == []
-    # Direction changed, so at t=2.0 the 'Down' key is brand new (started_at=2.0);
-    # nowhere near the 5s gaze_away threshold yet.
-    assert fh._confirmed_anomalies('s1', ['gaze_away:Down']) == []
+    assert fh._confirmed_anomalies('s1', ['gaze_away:Down']) == ['gaze_away:Down']
 
 
 def test_sustained_same_direction_confirms_after_threshold(monkeypatch):
     _reset_state()
-    # Must clear both the persistence threshold (GAZE_AWAY_SECONDS, default 2s
-    # from started_at) AND the cooldown (WARNING_COOLDOWN_SECONDS, default 15s
-    # from last_logged_at, which starts at 0.0).
-    times = iter([0.0, 1.0, 16.0])
+    times = iter([0.0, 1.0, 2.0])
     monkeypatch.setattr(fh.time, 'monotonic', lambda: next(times))
 
     assert fh._confirmed_anomalies('s2', ['gaze_away:Right']) == []
     assert fh._confirmed_anomalies('s2', ['gaze_away:Right']) == []
     assert fh._confirmed_anomalies('s2', ['gaze_away:Right']) == ['gaze_away:Right']
+
+
+def test_rolling_window_recovers_after_anomaly_stops(monkeypatch):
+    _reset_state()
+    times = iter([0.0, 1.0, 4.1])
+    monkeypatch.setattr(fh.time, 'monotonic', lambda: next(times))
+
+    assert fh._confirmed_anomalies('s3', ['gaze_away:Right']) == []
+    assert fh._confirmed_anomalies('s3', []) == []
+    assert fh._confirmed_anomalies('s3', ['gaze_away:Right']) == []
+
+
+def test_confirmed_anomaly_respects_cooldown(monkeypatch):
+    _reset_state()
+    times = iter([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0])
+    monkeypatch.setattr(fh.time, 'monotonic', lambda: next(times))
+
+    assert fh._confirmed_anomalies('s4', ['gaze_away:Right']) == []
+    assert fh._confirmed_anomalies('s4', ['gaze_away:Right']) == []
+    assert fh._confirmed_anomalies('s4', ['gaze_away:Right']) == ['gaze_away:Right']
+    assert fh._confirmed_anomalies('s4', ['gaze_away:Right']) == []
+    assert fh._confirmed_anomalies('s4', ['gaze_away:Right']) == []
+    assert fh._confirmed_anomalies('s4', ['gaze_away:Right']) == []
+    assert fh._confirmed_anomalies('s4', ['gaze_away:Right']) == []
+    assert fh._confirmed_anomalies('s4', ['gaze_away:Right']) == ['gaze_away:Right']
 
 
 def _is_away(direction, confidence):


### PR DESCRIPTION
## Summary

- Replaces same-direction anomaly persistence with a rolling evidence window keyed by anomaly type.
- Allows gaze-away jitter across non-Screen directions to accumulate as suspicious behavior instead of resetting the timer every direction change.
- Keeps cooldown behavior for repeated logs and adds tests for jitter, recovery, sustained anomalies, and cooldown.

## Why

Closes #106. The audit found that brittle same-direction debounce logic makes the monitor unstable when the gaze classifier jitters between adjacent wrong directions.

## Validation

- python3 -m compileall ai-service/sockets/frame_handler.py ai-service/tests/test_frame_handler_debounce.py
- pytest could not run in this environment because pytest was not installed, and installing ai-service/requirements.txt into a disposable venv was blocked by unavailable mediapipe==0.10.14 for this Python/platform combo.