### PR TITLE
Add session gaze calibration

### DIFF
--- a/ai-service/sockets/frame_handler.py
+++ b/ai-service/sockets/frame_handler.py
@@ -21,6 +21,7 @@ _AI_SERVICE_TOKEN = os.getenv('AI_SERVICE_TOKEN', '').strip()
 _warning_counts: dict = {}
 _anomaly_states: dict = {}
 _baseline_pose: dict = {}
+_gaze_calibration: dict = {}
 _session_student_id: dict = {}
 _identity_check_state: dict = {}
 _lock = threading.Lock()
@@ -44,6 +45,7 @@ _IDENTITY_MISMATCH_CONFIRM_COUNT = int(os.getenv('IDENTITY_MISMATCH_CONFIRM_COUN
 # camera check most real proctoring systems run before the timed test
 # starts) fixes that.
 _HEAD_POSE_CALIBRATION_FRAMES = int(os.getenv('HEAD_POSE_CALIBRATION_FRAMES', '5'))
+_GAZE_CALIBRATION_FRAMES = int(os.getenv('GAZE_CALIBRATION_FRAMES', str(_HEAD_POSE_CALIBRATION_FRAMES)))
 
 _ANOMALY_SECONDS = {
     'gaze_away': float(os.getenv('GAZE_AWAY_SECONDS', '2')),
@@ -139,6 +141,41 @@ def _representative_anomaly(observations):
     if not qualified:
         return observations[-1][1]
     return Counter(qualified).most_common(1)[0][0]
+
+
+def _calibrated_gaze(session_id, gaze, calibrating):
+    """Use setup-time neutral gaze samples to correct session-specific bias."""
+    if gaze is None:
+        return None
+
+    direction = gaze.get('direction')
+    calibrated = dict(gaze)
+    calibrated.setdefault('raw_direction', direction)
+
+    with _lock:
+        state = _gaze_calibration.setdefault(
+            session_id,
+            {'samples': [], 'neutral_direction': None},
+        )
+
+        if state['neutral_direction'] is None and calibrating:
+            if direction:
+                state['samples'].append(direction)
+            if len(state['samples']) >= _GAZE_CALIBRATION_FRAMES:
+                state['neutral_direction'] = Counter(state['samples']).most_common(1)[0][0]
+            calibrated['calibrating'] = True
+            calibrated['neutral_direction'] = state['neutral_direction']
+            return calibrated
+
+        neutral_direction = state['neutral_direction']
+
+    if neutral_direction:
+        calibrated['neutral_direction'] = neutral_direction
+        if direction == neutral_direction:
+            calibrated['direction'] = 'Screen'
+            calibrated['calibrated_from'] = direction
+
+    return calibrated
 
 
 def _confirmed_anomalies(session_id, current_anomalies):
@@ -335,6 +372,8 @@ def register_handlers(socketio: SocketIO):
         head_alert, calibrating = (False, not already_calibrated)
         if pose is not None:
             head_alert, calibrating = _calibrated_head_alert(session_id, pose)
+
+        gaze = _calibrated_gaze(session_id, gaze, calibrating)
 
         print(
             f"[pose_debug] session={session_id} "

--- a/ai-service/tests/test_frame_handler_calibration_gate.py
+++ b/ai-service/tests/test_frame_handler_calibration_gate.py
@@ -24,6 +24,7 @@ def socket_client(monkeypatch):
     fh._anomaly_states.clear()
     fh._warning_counts.clear()
     fh._baseline_pose.clear()
+    fh._gaze_calibration.clear()
     fh._identity_check_state.clear()
     fh._session_student_id.clear()
     # Avoid real network calls to the backend for the identity re-check path;
@@ -65,17 +66,23 @@ def test_anomaly_tracking_resumes_once_calibration_is_done(monkeypatch, socket_c
     """Once calibration has actually finished, a genuinely sustained
     away-gaze reading should be tracked (and eventually confirmed) exactly
     as before this fix."""
-    monkeypatch.setattr(fh, 'estimate_gaze', lambda img: {'direction': 'Down', 'confidence': 0.95, 'model_available': True})
     monkeypatch.setattr(fh, 'estimate_head_pose', lambda img: {'yaw': -2.0, 'pitch': -10.0, 'roll': 0.0, 'alert': False})
     monkeypatch.setattr(fh, 'count_faces', lambda img: 1)
 
     frame_base64 = _dummy_frame_base64()
     session_id = 'post-calib-session'
 
+    # Report a neutral "Screen" gaze during calibration so gaze
+    # calibration (_calibrated_gaze) learns "Screen", not "Down", as this
+    # session's own resting direction - otherwise the "Down" reading below
+    # would get remapped back to "Screen" as calibrated neutral, masking
+    # the very anomaly this test checks for.
+    monkeypatch.setattr(fh, 'estimate_gaze', lambda img: {'direction': 'Screen', 'confidence': 0.95, 'model_available': True})
     for _ in range(fh._HEAD_POSE_CALIBRATION_FRAMES):
         socket_client.emit('webcam_frame', {'session_id': session_id, 'frame_base64': frame_base64})
         socket_client.get_received()
 
+    monkeypatch.setattr(fh, 'estimate_gaze', lambda img: {'direction': 'Down', 'confidence': 0.95, 'model_available': True})
     socket_client.emit('webcam_frame', {'session_id': session_id, 'frame_base64': frame_base64})
     payload = _get_anomaly_result(socket_client)
     assert payload['calibrating'] is False

--- a/ai-service/tests/test_frame_handler_debounce.py
+++ b/ai-service/tests/test_frame_handler_debounce.py
@@ -12,6 +12,7 @@ def _reset_state():
     fh._anomaly_states.clear()
     fh._warning_counts.clear()
     fh._baseline_pose.clear()
+    fh._gaze_calibration.clear()
 
 
 def _reset_identity_state():
@@ -139,6 +140,34 @@ def test_real_deviation_from_baseline_still_alerts():
     alert, calibrating = fh._calibrated_head_alert('s5', {'yaw': -58.0, 'pitch': -43.0, 'roll': -4.0})
     assert calibrating is False
     assert alert is True
+
+
+def test_gaze_calibration_maps_neutral_direction_to_screen():
+    _reset_state()
+    neutral = {'direction': 'Left', 'confidence': 0.8, 'model_available': True}
+
+    for _ in range(fh._GAZE_CALIBRATION_FRAMES):
+        calibrated = fh._calibrated_gaze('gaze1', neutral, calibrating=True)
+        assert calibrated['calibrating'] is True
+
+    calibrated = fh._calibrated_gaze('gaze1', neutral, calibrating=False)
+
+    assert calibrated['raw_direction'] == 'Left'
+    assert calibrated['neutral_direction'] == 'Left'
+    assert calibrated['calibrated_from'] == 'Left'
+    assert calibrated['direction'] == 'Screen'
+
+
+def test_gaze_calibration_keeps_non_neutral_direction():
+    _reset_state()
+    for _ in range(fh._GAZE_CALIBRATION_FRAMES):
+        fh._calibrated_gaze('gaze2', {'direction': 'Screen', 'confidence': 0.8}, calibrating=True)
+
+    calibrated = fh._calibrated_gaze('gaze2', {'direction': 'Up', 'confidence': 0.9}, calibrating=False)
+
+    assert calibrated['raw_direction'] == 'Up'
+    assert calibrated['neutral_direction'] == 'Screen'
+    assert calibrated['direction'] == 'Up'
 
 
 def test_resolve_student_id_caches_after_first_lookup(monkeypatch):


### PR DESCRIPTION
## Summary

- Adds session-local gaze calibration during the existing monitoring setup window.
- Captures neutral gaze samples and maps the dominant neutral prediction to Screen for that active session.
- Adds tests for neutral-direction remapping and preserving true non-neutral gaze.

## Why

Closes #108. The audit found that live gaze normalization needs calibration similar to the head-pose baseline so candidate camera position and model bias do not immediately become false gaze-away evidence.

## Validation

- python3 -m compileall ai-service/sockets/frame_handler.py ai-service/tests/test_frame_handler_debounce.py
- pytest could not run in this environment because pytest was not installed, and installing ai-service/requirements.txt into a disposable venv was blocked by unavailable mediapipe==0.10.14 for this Python/platform combo.