### PR TITLE
Weight gaze evidence by direction

### DIFF
--- a/ai-service/sockets/frame_handler.py
+++ b/ai-service/sockets/frame_handler.py
@@ -66,6 +66,12 @@ _WARNING_COOLDOWN_SECONDS = float(os.getenv('WARNING_COOLDOWN_SECONDS', '5'))
 # inconclusive rather than "away" — see the 2026-07-02 warning-escalation
 # investigation.
 _GAZE_CONFIDENCE_THRESHOLD = float(os.getenv('GAZE_CONFIDENCE_THRESHOLD', '0.4'))
+_GAZE_DIRECTION_WEIGHTS = {
+    'Down': float(os.getenv('GAZE_WEIGHT_DOWN', '1.0')),
+    'Up': float(os.getenv('GAZE_WEIGHT_UP', '1.0')),
+    'Left': float(os.getenv('GAZE_WEIGHT_LEFT', '0.75')),
+    'Right': float(os.getenv('GAZE_WEIGHT_RIGHT', '0.75')),
+}
 
 # Directions that count as "looking away" for warning purposes. All four
 # non-Screen classes now escalate (policy decision 2026-07-03: previously
@@ -84,6 +90,20 @@ _AWAY_DIRECTIONS = {'Down', 'Up', 'Left', 'Right'}
 def _base_type(anomaly):
     """Strip the ':direction' qualifier some anomaly keys carry internally."""
     return anomaly.split(':', 1)[0]
+
+
+def _gaze_evidence(gaze):
+    direction = gaze.get('direction') if gaze else None
+    confidence = float(gaze.get('confidence', 0.0)) if gaze else 0.0
+    weight = _GAZE_DIRECTION_WEIGHTS.get(direction, 0.0)
+    score = confidence * weight
+    return {
+        'direction': direction,
+        'confidence': confidence,
+        'weight': weight,
+        'score': score,
+        'is_away': direction in _AWAY_DIRECTIONS and score >= _GAZE_CONFIDENCE_THRESHOLD,
+    }
 
 
 def _calibrated_head_alert(session_id, pose):
@@ -321,10 +341,11 @@ def register_handlers(socketio: SocketIO):
             identity_mismatch_confirmed, identity_confidence = _check_identity_mismatch(session_id, img_bgr)
 
         anomalies = []
+        gaze_evidence = _gaze_evidence(gaze)
         if not calibrating:
             if gaze is None or face_count[0] == 0:
                 anomalies.append('face_absent')
-            elif gaze.get('direction') in _AWAY_DIRECTIONS and gaze.get('confidence', 0.0) >= _GAZE_CONFIDENCE_THRESHOLD:
+            elif gaze_evidence['is_away']:
                 anomalies.append(f"gaze_away:{gaze['direction']}")
 
             if head_alert:
@@ -422,6 +443,11 @@ def register_handlers(socketio: SocketIO):
             'confirmed_anomalies': [_base_type(a) for a in confirmed_anomalies],
             'warning_count':  warning_count,
             'gaze_direction': gaze_direction,
+            'gaze_evidence': {
+                'confidence': round(gaze_evidence['confidence'], 4),
+                'weight': round(gaze_evidence['weight'], 4),
+                'score': round(gaze_evidence['score'], 4),
+            },
             'calibrating':    calibrating,
         })
 

--- a/ai-service/tests/test_frame_handler_debounce.py
+++ b/ai-service/tests/test_frame_handler_debounce.py
@@ -52,7 +52,7 @@ def test_sustained_same_direction_confirms_after_threshold(monkeypatch):
 
 
 def _is_away(direction, confidence):
-    return direction in fh._AWAY_DIRECTIONS and confidence >= fh._GAZE_CONFIDENCE_THRESHOLD
+    return fh._gaze_evidence({'direction': direction, 'confidence': confidence})['is_away']
 
 
 def test_low_confidence_reading_is_not_flagged_as_anomaly():
@@ -73,6 +73,12 @@ def test_all_four_directions_are_treated_as_away_above_confidence_floor():
     assert _is_away('Right', 0.9) is True
     assert _is_away('Down', 0.1) is False
     assert _is_away('Left', 0.1) is False
+
+
+def test_horizontal_gaze_uses_weaker_evidence_weight():
+    assert fh._gaze_evidence({'direction': 'Up', 'confidence': 0.45})['is_away'] is True
+    assert fh._gaze_evidence({'direction': 'Left', 'confidence': 0.45})['is_away'] is False
+    assert fh._gaze_evidence({'direction': 'Right', 'confidence': 0.45})['score'] < 0.45
 
 
 def test_calibration_window_never_alerts_regardless_of_raw_pose():


### PR DESCRIPTION
## Summary

- Adds configurable gaze direction weights, with Left/Right weaker by default than Up/Down.
- Uses weighted confidence scores for gaze-away anomaly decisions.
- Emits gaze evidence metadata so reviewers can see confidence, weight, and score.
- Adds tests for horizontal evidence being weaker than vertical evidence.

## Why

Closes #109. The audit found that Left/Right gaze predictions should be treated as weaker evidence than Up/Down because horizontal eye movement is more ambiguous during normal screen reading.

## Validation

- python3 -m compileall ai-service/sockets/frame_handler.py ai-service/tests/test_frame_handler_debounce.py
- pytest could not run in this environment because pytest was not installed, and installing ai-service/requirements.txt into a disposable venv was blocked by unavailable mediapipe==0.10.14 for this Python/platform combo.