### PR TITLE
Add local-only Exam Lab dev workflow for the exam module

### DIFF
--- a/ai-service/sockets/frame_handler.py
+++ b/ai-service/sockets/frame_handler.py
@@ -66,6 +66,12 @@ _WARNING_COOLDOWN_SECONDS = float(os.getenv('WARNING_COOLDOWN_SECONDS', '5'))
 # inconclusive rather than "away" — see the 2026-07-02 warning-escalation
 # investigation.
 _GAZE_CONFIDENCE_THRESHOLD = float(os.getenv('GAZE_CONFIDENCE_THRESHOLD', '0.4'))
+_GAZE_DIRECTION_WEIGHTS = {
+    'Down': float(os.getenv('GAZE_WEIGHT_DOWN', '1.0')),
+    'Up': float(os.getenv('GAZE_WEIGHT_UP', '1.0')),
+    'Left': float(os.getenv('GAZE_WEIGHT_LEFT', '0.75')),
+    'Right': float(os.getenv('GAZE_WEIGHT_RIGHT', '0.75')),
+}
 
 # Directions that count as "looking away" for warning purposes. All four
 # non-Screen classes now escalate (policy decision 2026-07-03: previously
@@ -84,6 +90,20 @@ _AWAY_DIRECTIONS = {'Down', 'Up', 'Left', 'Right'}
 def _base_type(anomaly):
     """Strip the ':direction' qualifier some anomaly keys carry internally."""
     return anomaly.split(':', 1)[0]
+
+
+def _gaze_evidence(gaze):
+    direction = gaze.get('direction') if gaze else None
+    confidence = float(gaze.get('confidence', 0.0)) if gaze else 0.0
+    weight = _GAZE_DIRECTION_WEIGHTS.get(direction, 0.0)
+    score = confidence * weight
+    return {
+        'direction': direction,
+        'confidence': confidence,
+        'weight': weight,
+        'score': score,
+        'is_away': direction in _AWAY_DIRECTIONS and score >= _GAZE_CONFIDENCE_THRESHOLD,
+    }
 
 
 def _calibrated_head_alert(session_id, pose):
@@ -321,10 +341,11 @@ def register_handlers(socketio: SocketIO):
             identity_mismatch_confirmed, identity_confidence = _check_identity_mismatch(session_id, img_bgr)
 
         anomalies = []
+        gaze_evidence = _gaze_evidence(gaze)
         if not calibrating:
             if gaze is None or face_count[0] == 0:
                 anomalies.append('face_absent')
-            elif gaze.get('direction') in _AWAY_DIRECTIONS and gaze.get('confidence', 0.0) >= _GAZE_CONFIDENCE_THRESHOLD:
+            elif gaze_evidence['is_away']:
                 anomalies.append(f"gaze_away:{gaze['direction']}")
 
             if head_alert:
@@ -422,6 +443,11 @@ def register_handlers(socketio: SocketIO):
             'confirmed_anomalies': [_base_type(a) for a in confirmed_anomalies],
             'warning_count':  warning_count,
             'gaze_direction': gaze_direction,
+            'gaze_evidence': {
+                'confidence': round(gaze_evidence['confidence'], 4),
+                'weight': round(gaze_evidence['weight'], 4),
+                'score': round(gaze_evidence['score'], 4),
+            },
             'calibrating':    calibrating,
         })
 

--- a/ai-service/tests/test_frame_handler_debounce.py
+++ b/ai-service/tests/test_frame_handler_debounce.py
@@ -52,7 +52,7 @@ def test_sustained_same_direction_confirms_after_threshold(monkeypatch):
 
 
 def _is_away(direction, confidence):
-    return direction in fh._AWAY_DIRECTIONS and confidence >= fh._GAZE_CONFIDENCE_THRESHOLD
+    return fh._gaze_evidence({'direction': direction, 'confidence': confidence})['is_away']
 
 
 def test_low_confidence_reading_is_not_flagged_as_anomaly():
@@ -73,6 +73,12 @@ def test_all_four_directions_are_treated_as_away_above_confidence_floor():
     assert _is_away('Right', 0.9) is True
     assert _is_away('Down', 0.1) is False
     assert _is_away('Left', 0.1) is False
+
+
+def test_horizontal_gaze_uses_weaker_evidence_weight():
+    assert fh._gaze_evidence({'direction': 'Up', 'confidence': 0.45})['is_away'] is True
+    assert fh._gaze_evidence({'direction': 'Left', 'confidence': 0.45})['is_away'] is False
+    assert fh._gaze_evidence({'direction': 'Right', 'confidence': 0.45})['score'] < 0.45
 
 
 def test_calibration_window_never_alerts_regardless_of_raw_pose():

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -40,3 +40,10 @@ BOOTSTRAP_ADMIN_USERNAME=admin.temp
 BOOTSTRAP_ADMIN_EMAIL=admin@udom.ac.tz
 BOOTSTRAP_ADMIN_REG_NUMBER=ADM-BOOTSTRAP-001
 BOOTSTRAP_ADMIN_PASSWORD=TempAdmin123!
+
+# Exam Lab dev-only bootstrap endpoints (app/devtools/routes.py). Lets you
+# seed a deterministic dev student + exam + verified session for local exam
+# module development, without repeating login/exam-creation/identity
+# verification each time. Requires FLASK_ENV=development as well - see
+# app/config.py::Config.ENABLE_DEV_TOOLS. Never enable this in production.
+ENABLE_DEV_TOOLS=false

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -17,6 +17,7 @@ from sqlalchemy.exc import OperationalError, ProgrammingError
 
 from app.auth.routes import auth_bp
 from app.config import Config
+from app.devtools.routes import devtools_bp
 from app.exams.routes import exams_bp
 from app.extensions import db, jwt, migrate
 from app.images.routes import images_bp
@@ -51,6 +52,13 @@ def create_app() -> Flask:
     app.register_blueprint(reports_bp, url_prefix="/api/reports")
     app.register_blueprint(images_bp, url_prefix="/api/images")
     app.register_blueprint(search_bp, url_prefix="/api/search")
+
+    # Exam Lab dev-only bootstrap routes - only exist at all when explicitly
+    # enabled for local development (see Config.ENABLE_DEV_TOOLS). Never
+    # registered otherwise, so the routes 404 exactly as if the code weren't
+    # present.
+    if app.config.get("ENABLE_DEV_TOOLS"):
+        app.register_blueprint(devtools_bp, url_prefix="/api/devtools")
 
     @app.get("/health")
     def health_check():

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -15,3 +15,12 @@ class Config:
     BOOTSTRAP_ADMIN_EMAIL = os.getenv("BOOTSTRAP_ADMIN_EMAIL", "admin@udom.ac.tz")
     BOOTSTRAP_ADMIN_REG_NUMBER = os.getenv("BOOTSTRAP_ADMIN_REG_NUMBER", "ADM-BOOTSTRAP-001")
     BOOTSTRAP_ADMIN_PASSWORD = os.getenv("BOOTSTRAP_ADMIN_PASSWORD", "TempAdmin123!")
+
+    # Exam Lab dev-only bootstrap endpoints (app/devtools/routes.py). Requires
+    # BOTH flags so a stray ENABLE_DEV_TOOLS=true can't light this up outside
+    # local development - the blueprint is only registered at all when this
+    # is true (see create_app()).
+    ENABLE_DEV_TOOLS = (
+        os.getenv("ENABLE_DEV_TOOLS", "false").strip().lower() == "true"
+        and os.getenv("FLASK_ENV", "production").strip().lower() == "development"
+    )

--- a/backend/app/devtools/routes.py
+++ b/backend/app/devtools/routes.py
@@ -1,0 +1,237 @@
+"""
+Exam Lab dev-only bootstrap endpoints.
+
+These exist so the exam module can be developed and re-tested repeatedly
+without manually logging in, creating an exam, and completing facial
+identity verification every time. They are NOT a shortcut around any
+production security check: the endpoints below seed real rows in the
+same tables the normal flow uses (User, Exam, Question,
+ExamStudentAssignment, ExamSession), including a genuinely
+`identity_verified=True` ExamSession row - so the real, unmodified
+`GET /sessions/<id>/status` check on the /exam page still passes
+honestly rather than being bypassed.
+
+This entire blueprint is only registered by create_app() when
+Config.ENABLE_DEV_TOOLS is true, which itself requires BOTH
+ENABLE_DEV_TOOLS=true AND FLASK_ENV=development (see app/config.py) -
+so it does not exist at all unless explicitly enabled in local dev.
+_require_dev_tools() re-checks the same flag inside each route as
+defense in depth.
+"""
+
+import base64
+import os
+from datetime import datetime
+
+from flask import Blueprint, current_app, jsonify
+from flask_jwt_extended import create_access_token
+
+from app.extensions import db
+from app.models import (
+    BehavioralLog,
+    DegreeProgram,
+    Exam,
+    ExamSession,
+    ExamStudentAssignment,
+    FacialImage,
+    Question,
+    SessionAnswer,
+    User,
+)
+
+devtools_bp = Blueprint("devtools", __name__)
+
+DEV_LECTURER_REG_NUMBER = "DEV-LEC-0001"
+DEV_LECTURER_EMAIL = "dev.lecturer@examlab.local"
+DEV_LECTURER_USERNAME = "dev.lecturer"
+DEV_STUDENT_REG_NUMBER = "DEV-STU-0001"
+DEV_STUDENT_EMAIL = "dev.student@examlab.local"
+DEV_PASSWORD = "ExamLabDev123!"
+DEV_PROGRAM_NAME = "Exam Lab Sandbox Program"
+DEV_EXAM_TITLE = "Exam Lab Sandbox Exam"
+DEV_EXAM_COURSE_CODE = "DEVLAB101"
+
+# 1x1 black pixel JPEG - only used as a placeholder baseline image row so
+# the dev student's profile looks complete. Exam Lab never runs real face
+# matching against it; it seeds identity_verified=True directly on the
+# session it creates instead.
+_PLACEHOLDER_JPEG_B64 = (
+    "/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a"
+    "HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy"
+    "MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAABAAEDASIA"
+    "AhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAn/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEB"
+    "AQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCdABmX"
+    "/9k="
+)
+
+
+def _dev_tools_enabled() -> bool:
+    return bool(current_app.config.get("ENABLE_DEV_TOOLS"))
+
+
+def _require_dev_tools():
+    if not _dev_tools_enabled():
+        return jsonify({"error": {"message": "Exam Lab dev tools are disabled"}}), 404
+    return None
+
+
+@devtools_bp.get("/exam-lab/status")
+def exam_lab_status():
+    return jsonify({"enabled": _dev_tools_enabled()}), 200
+
+
+@devtools_bp.post("/exam-lab/bootstrap")
+def exam_lab_bootstrap():
+    blocked = _require_dev_tools()
+    if blocked:
+        return blocked
+
+    program = DegreeProgram.query.filter_by(name=DEV_PROGRAM_NAME).first()
+    if not program:
+        program = DegreeProgram(name=DEV_PROGRAM_NAME)
+        db.session.add(program)
+        db.session.flush()
+
+    lecturer = User.query.filter_by(reg_number=DEV_LECTURER_REG_NUMBER).first()
+    if not lecturer:
+        lecturer = User(
+            full_name="Exam Lab Dev Lecturer",
+            reg_number=DEV_LECTURER_REG_NUMBER,
+            email=DEV_LECTURER_EMAIL,
+            username=DEV_LECTURER_USERNAME,
+            role="lecturer",
+            department=program.name,
+            credential_source="dev_bootstrap",
+            lecturer_profile_confirmed=True,
+            is_active=True,
+        )
+        lecturer.set_password(DEV_PASSWORD)
+        db.session.add(lecturer)
+        db.session.flush()
+
+    student = User.query.filter_by(reg_number=DEV_STUDENT_REG_NUMBER).first()
+    if not student:
+        student = User(
+            full_name="Exam Lab Dev Student",
+            reg_number=DEV_STUDENT_REG_NUMBER,
+            email=DEV_STUDENT_EMAIL,
+            role="student",
+            department=program.name,
+            phone_number="+255000000000",
+            academic_year="1",
+            year_enrolled=datetime.utcnow().year,
+            credential_source="dev_bootstrap",
+            student_profile_confirmed=True,
+            is_active=True,
+        )
+        student.set_password(DEV_PASSWORD)
+        db.session.add(student)
+        db.session.flush()
+
+    if not FacialImage.query.filter_by(user_id=student.user_id).first():
+        storage_dir = os.path.join("storage", "faces")
+        os.makedirs(storage_dir, exist_ok=True)
+        file_name = f"{student.user_id}_examlab_placeholder.jpg"
+        file_path = os.path.join(storage_dir, file_name)
+        with open(file_path, "wb") as face_file:
+            face_file.write(base64.b64decode(_PLACEHOLDER_JPEG_B64))
+        db.session.add(FacialImage(user_id=student.user_id, file_path=file_path))
+
+    exam = Exam.query.filter_by(course_code=DEV_EXAM_COURSE_CODE, lecturer_id=lecturer.user_id).first()
+    if not exam:
+        exam = Exam(
+            title=DEV_EXAM_TITLE,
+            course_code=DEV_EXAM_COURSE_CODE,
+            lecturer_id=lecturer.user_id,
+            duration_min=30,
+            status="live",
+            programs=[program],
+        )
+        db.session.add(exam)
+        db.session.flush()
+    elif exam.status != "live":
+        exam.status = "live"
+
+    if not ExamStudentAssignment.query.filter_by(exam_id=exam.exam_id, student_id=student.user_id).first():
+        db.session.add(
+            ExamStudentAssignment(exam_id=exam.exam_id, student_id=student.user_id, added_by=lecturer.user_id)
+        )
+
+    if Question.query.filter_by(exam_id=exam.exam_id).count() == 0:
+        seed_questions = [
+            ("What is the time complexity of binary search on a sorted array?", "B", "O(n)", "O(log n)", "O(n log n)", "O(1)"),
+            ("Which layer of the OSI model is responsible for routing?", "C", "Data Link", "Transport", "Network", "Session"),
+            ("In SQL, which statement removes rows from a table?", "B", "DROP", "DELETE", "TRUNCATE", "REMOVE"),
+            ("A stack follows which access order?", "D", "FIFO", "Random", "Priority", "LIFO"),
+            ("Which of these is NOT a valid HTTP method?", "A", "FETCH", "GET", "POST", "DELETE"),
+        ]
+        for order_num, (text, correct, a, b, c, d) in enumerate(seed_questions, start=1):
+            db.session.add(
+                Question(
+                    exam_id=exam.exam_id,
+                    question_text=text,
+                    question_type="mcq",
+                    option_a=a,
+                    option_b=b,
+                    option_c=c,
+                    option_d=d,
+                    correct_answer=correct,
+                    marks=1,
+                    order_num=order_num,
+                )
+            )
+
+    db.session.flush()
+
+    session = ExamSession.query.filter_by(student_id=student.user_id, exam_id=exam.exam_id).first()
+    now = datetime.utcnow()
+    if session:
+        SessionAnswer.query.filter_by(session_id=session.session_id).delete(synchronize_session=False)
+        BehavioralLog.query.filter_by(session_id=session.session_id).delete(synchronize_session=False)
+        session.session_status = "active"
+        session.identity_verified = True
+        session.verification_score = 1.0
+        session.verification_method = "exam-lab-dev-bootstrap"
+        session.verification_details = {"source": "exam_lab_bootstrap"}
+        session.verified_at = now
+        session.started_at = now
+        session.warning_count = 0
+        session.score = None
+        session.submitted_at = None
+        session.termination_reason = None
+        session.terminated_by = None
+    else:
+        session = ExamSession(
+            student_id=student.user_id,
+            exam_id=exam.exam_id,
+            started_at=now,
+            session_status="active",
+            identity_verified=True,
+            verification_score=1.0,
+            verification_method="exam-lab-dev-bootstrap",
+            verification_details={"source": "exam_lab_bootstrap"},
+            verified_at=now,
+            warning_count=0,
+        )
+        db.session.add(session)
+
+    db.session.commit()
+
+    token = create_access_token(identity=str(student.user_id), additional_claims={"role": student.role})
+
+    return (
+        jsonify(
+            {
+                "token": token,
+                "user": student.to_auth_user(),
+                "session_id": session.session_id,
+                "exam_id": exam.exam_id,
+                "dev_credentials": {
+                    "student_login_id": student.reg_number,
+                    "lecturer_login_id": lecturer.username,
+                    "password": DEV_PASSWORD,
+                },
+            }
+        ),
+        200,
+    )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,10 @@ services:
       ADMIN_EMAIL: admin@udom.ac.tz
       AI_SERVICE_URL: http://ai-service:8000
       FLASK_ENV: development
+      # Enables the local-only Exam Lab bootstrap endpoints (app/devtools).
+      # Requires FLASK_ENV=development above too - see app/config.py. Set to
+      # "false" (or unset) to keep this dev-only surface off even locally.
+      ENABLE_DEV_TOOLS: ${ENABLE_DEV_TOOLS:-true}
     depends_on:
       postgres:
         condition: service_healthy
@@ -88,6 +92,11 @@ services:
     environment:
       NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:5000}
       NEXT_PUBLIC_WS_URL: ${NEXT_PUBLIC_WS_URL:-ws://localhost:8000}
+      # Purely a UI hint for the exam page's mock-monitoring toggle (see
+      # frontend/app/exam/page.tsx). The actual Exam Lab endpoints are
+      # gated server-side by the backend's ENABLE_DEV_TOOLS, independent of
+      # this - see backend/app/config.py.
+      NEXT_PUBLIC_ENABLE_DEV_TOOLS: ${NEXT_PUBLIC_ENABLE_DEV_TOOLS:-true}
     depends_on:
       - backend
       - ai-service

--- a/docs/exam-lab-local-testing.md
+++ b/docs/exam-lab-local-testing.md
@@ -1,0 +1,143 @@
+# Exam Lab — Local Exam Module Testing Guide
+
+Exam Lab is a **local-only** development shortcut for iterating on the exam module
+(`/exam`, session lifecycle, autosave, monitoring, lecturer intervention) without
+repeating login, exam creation, and facial identity verification on every run.
+
+It does **not** weaken production auth, session, or identity checks. It works by
+seeding real rows through the same tables the normal flow uses — including a
+genuinely `identity_verified=True` `ExamSession` — so the exam page's real,
+unmodified server-side checks (`GET /sessions/:id/status`, JWT auth, etc.) pass
+honestly instead of being bypassed. See `backend/app/devtools/routes.py` for
+the implementation and gating.
+
+**Gating:** the bootstrap endpoints only exist when the backend has both
+`ENABLE_DEV_TOOLS=true` **and** `FLASK_ENV=development` (`backend/app/config.py`).
+`docker-compose.yml` sets both by default for local dev. `docker-compose.api-prod.yml`
+sets neither — Exam Lab cannot be enabled in production through that compose file.
+
+---
+
+## 1. Docker startup
+
+```bash
+docker-compose up --build
+```
+
+Services: `postgres` (15432), `backend` (5000), `ai-service` (8000), `frontend` (3000).
+
+## 2. Health checks
+
+```bash
+curl http://localhost:5000/health
+curl http://localhost:8000/health
+curl http://localhost:5000/api/devtools/exam-lab/status
+```
+
+The last call should return `{"enabled": true}` when running via `docker-compose up`.
+If it 404s, `ENABLE_DEV_TOOLS`/`FLASK_ENV` aren't both set to enable it — check the
+`backend` service environment.
+
+## 3. Normal (production-shaped) flow — sanity check, not Exam Lab
+
+1. Open `http://localhost:3000`, log in as a real/admin-provisioned student.
+2. Dashboard → start an assigned exam → redirected to `/verify`.
+3. Complete facial verification (needs a webcam and the AI service's face models).
+4. Redirected to `/exam`; answer questions, submit.
+
+Use this path to confirm the real flow still works end-to-end after any exam-module change.
+
+## 4. Exam Lab flow (fast iteration)
+
+1. Open `http://localhost:3000/exam-lab`.
+2. It calls `GET /api/devtools/exam-lab/status`; if disabled you'll see a message
+   telling you which env vars to set — it does not silently no-op.
+3. Click **Launch with Real Monitoring** or **Launch with Mock Monitoring**.
+   - This calls `POST /api/devtools/exam-lab/bootstrap`, which upserts a
+     deterministic dev lecturer (`DEV-LEC-0001`), dev student (`DEV-STU-0001`),
+     a "Exam Lab Sandbox Program" degree program, a "Exam Lab Sandbox Exam"
+     (5 MCQ questions), an assignment, and an `ExamSession` that's already
+     `active` + `identity_verified=True`.
+   - The response's real JWT + `session_id`/`exam_id` are stored in
+     `localStorage`/cookies exactly like the normal login/dashboard flow, then
+     the browser is routed straight to the real `/exam` page.
+4. Re-launching at any point **resets** the dev session: clears answers,
+   warnings, and any terminated/completed state back to a clean `active`
+   session — this is your reset/cleanup path, see §11.
+
+**Real Monitoring** behaves exactly like the normal flow's camera/AI-socket
+pipeline (needs a webcam and the `ai-service` container with `.onnx` models
+present). **Mock Monitoring** sets a `exam_lab_mock_monitoring` localStorage
+flag that the exam page checks (only ever honored when the frontend was built
+with `NEXT_PUBLIC_ENABLE_DEV_TOOLS=true`, which the Vercel production build
+never sets) — it skips requesting the camera and connecting to the AI socket
+entirely and marks monitoring "calibrated" immediately so the exam timer isn't
+stuck waiting on a camera. It does not touch auth/session/identity checks.
+
+## 5. Manual submission
+
+From `/exam`, answer a few questions, click **Submit** → confirm. Verify:
+- `POST /sessions/:id/submit` returns a score.
+- The "Congratulations" modal shows the score.
+- `GET /api/sessions` (as the dev lecturer or an admin) shows the session as `completed`.
+
+## 6. Timeout (auto-submit at 0)
+
+The dev exam's duration is 30 minutes. To test the timeout path quickly, either:
+- Temporarily lower `duration_min` for the "Exam Lab Sandbox Exam" via the
+  lecturer UI (log in as `DEV-LEC-0001` / the password Exam Lab prints), or
+- Patch `timeLeft` briefly in devtools for a manual check (not a substitute
+  for a real timed run before release).
+
+Confirm the "Time's Up" modal appears and `submit` fires automatically exactly once.
+
+## 7. Autosave
+
+Answer a question, then hit `GET /api/sessions/:id/answers` (with the dev
+student's token) directly — the answer should already be persisted via
+`POST /sessions/:id/answer`, before you ever click Submit. Refresh `/exam` and
+confirm previously-selected answers are restored.
+
+## 8. Tab switch detection
+
+While in `/exam` (fullscreen), switch tabs or minimize the window. A
+`tab_switch` `BehavioralLog` row should be created (`POST /sessions/log`) and
+`warning_count` incremented — check via `GET /api/sessions`. This never
+interrupts the exam; it's logged for lecturer/admin review only.
+
+## 9. Camera permission failure
+
+Launch with **Real Monitoring**, then deny the camera permission prompt.
+Known current behavior (pre-existing, not introduced by Exam Lab): the
+"Camera permission denied" message shows in the monitor panel, but since
+`monitoringCalibrated` only ever flips true via a camera-gated path, the exam
+timer will not start either. Use this scenario to verify the error message
+renders correctly; if you need the exam to remain usable without a camera,
+use **Mock Monitoring** instead.
+
+## 10. AI events (real monitoring only)
+
+With the `ai-service` container running and `.onnx` models present under
+`ai-service/models/`, confirm in the browser devtools Network/WS tab that
+`webcam_frame` events are sent every ~2s and `anomaly_result` events come
+back. Trigger an anomaly (look away, cover the camera, hold up a second face)
+and confirm a `BehavioralLog` row appears and `warning_count` increments.
+
+## 11. Lecturer warn / terminate
+
+1. Log in as the dev lecturer (`DEV-LEC-0001`, password from the Exam Lab
+   launch response) in a second browser/incognito window, or as any admin.
+2. Go to Lecturer → Sessions & Reports, find the dev student's session.
+3. **Warn**: sends a real-time `manual_warning` socket event — the student's
+   `/exam` tab should show the "Message from Invigilator" modal without
+   interrupting the exam.
+4. **Terminate**: sends `session_terminated` — the student's tab should show
+   the "Session Terminated" modal with the score computed from whatever was
+   autosaved so far, and further `/submit` calls should be rejected (409).
+
+## 12. Cleanup / reset
+
+Re-visit `/exam-lab` and launch again — this resets the dev session back to a
+clean `active`, verified state (see §4). To remove the dev fixtures entirely,
+delete the `DEV-LEC-0001` / `DEV-STU-0001` users and the "Exam Lab Sandbox
+Exam" via the admin UI, or drop and re-`flask db upgrade` your local database.

--- a/frontend/app/exam-lab/page.tsx
+++ b/frontend/app/exam-lab/page.tsx
@@ -1,0 +1,148 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+import { getApiPath } from "@/lib/api-url"
+import { ThemeToggle } from "@/components/theme-toggle"
+
+type BootstrapResponse = {
+  token: string
+  user: Record<string, unknown>
+  session_id: number
+  exam_id: number
+  dev_credentials: {
+    student_login_id: string
+    lecturer_login_id: string
+    password: string
+  }
+}
+
+type Status = "checking" | "disabled" | "ready" | "launching" | "error"
+
+export default function ExamLabPage() {
+  const router = useRouter()
+  const [status, setStatus] = useState<Status>("checking")
+  const [error, setError] = useState<string | null>(null)
+  const [lastLaunch, setLastLaunch] = useState<BootstrapResponse | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const res = await fetch(getApiPath("/devtools/exam-lab/status"))
+        const payload = await res.json().catch(() => ({}))
+        if (cancelled) return
+        setStatus(res.ok && payload?.enabled === true ? "ready" : "disabled")
+      } catch {
+        if (!cancelled) setStatus("disabled")
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  // Seeds (or resets) a deterministic dev student + verified active session
+  // via the real backend contracts (see backend/app/devtools/routes.py),
+  // then enters the exam through the actual /exam page - no duplicated UI.
+  async function launch(mockMonitoring: boolean) {
+    setStatus("launching")
+    setError(null)
+    try {
+      const res = await fetch(getApiPath("/devtools/exam-lab/bootstrap"), { method: "POST" })
+      const payload: BootstrapResponse = await res.json().catch(() => ({}) as BootstrapResponse)
+      if (!res.ok) {
+        setError((payload as unknown as { error?: { message?: string } })?.error?.message || "Exam Lab bootstrap failed.")
+        setStatus("ready")
+        return
+      }
+
+      localStorage.setItem("token", payload.token)
+      localStorage.setItem("user", JSON.stringify(payload.user))
+      localStorage.setItem("session_id", String(payload.session_id))
+      localStorage.setItem("exam_id", String(payload.exam_id))
+      localStorage.removeItem("verified_session_id")
+      if (mockMonitoring) {
+        localStorage.setItem("exam_lab_mock_monitoring", "true")
+      } else {
+        localStorage.removeItem("exam_lab_mock_monitoring")
+      }
+      document.cookie = `auth_token=${payload.token}; Path=/; Max-Age=${60 * 60 * 8}; SameSite=Lax`
+
+      setLastLaunch(payload)
+      router.push("/exam")
+    } catch {
+      setError("Unable to reach the backend. Is docker-compose up?")
+      setStatus("ready")
+    }
+  }
+
+  return (
+    <main className="relative min-h-screen bg-[linear-gradient(165deg,#ebf2fb,#dfe9f8)] text-foreground dark:bg-[linear-gradient(165deg,#0e1526,#141d33)]">
+      <div className="absolute right-4 top-4 z-20">
+        <ThemeToggle />
+      </div>
+
+      <div className="mx-auto flex min-h-screen max-w-xl flex-col justify-center px-6 py-16">
+        <div className="rounded-2xl border border-slate-200 bg-white/90 p-8 shadow-lg backdrop-blur dark:border-slate-800 dark:bg-slate-900/90">
+          <h1 className="text-lg font-bold text-slate-900 dark:text-white">Exam Lab</h1>
+          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+            Local-only shortcut for developing the exam module. Seeds a deterministic dev student, exam, and an
+            already-verified active session, then opens the real exam page.
+          </p>
+
+          {status === "checking" && (
+            <p className="mt-6 text-sm text-slate-500 dark:text-slate-400">Checking whether Exam Lab is enabled on the backend&hellip;</p>
+          )}
+
+          {status === "disabled" && (
+            <div className="mt-6 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-300">
+              Exam Lab is disabled on this backend. Set <code className="font-mono">ENABLE_DEV_TOOLS=true</code> and{" "}
+              <code className="font-mono">FLASK_ENV=development</code> on the backend service, then reload this page.
+            </div>
+          )}
+
+          {(status === "ready" || status === "launching") && (
+            <div className="mt-6 flex flex-col gap-3">
+              <button
+                type="button"
+                disabled={status === "launching"}
+                onClick={() => void launch(false)}
+                className="rounded-md bg-[#1a2d5a] px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[#243d73] disabled:opacity-60"
+              >
+                {status === "launching" ? "Launching…" : "Launch with Real Monitoring (camera + AI service)"}
+              </button>
+              <button
+                type="button"
+                disabled={status === "launching"}
+                onClick={() => void launch(true)}
+                className="rounded-md border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-50 disabled:opacity-60 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-200 dark:hover:bg-slate-900"
+              >
+                {status === "launching" ? "Launching…" : "Launch with Mock Monitoring (no camera/socket)"}
+              </button>
+              <p className="text-xs text-slate-400">
+                Re-launching resets the dev session (answers, warnings, termination state) back to a clean, active,
+                verified session every time.
+              </p>
+            </div>
+          )}
+
+          {error && (
+            <div className="mt-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-300">
+              {error}
+            </div>
+          )}
+
+          {lastLaunch && (
+            <div className="mt-6 rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-xs text-slate-500 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-400">
+              <p>Dev student login: <span className="font-mono">{lastLaunch.dev_credentials.student_login_id}</span></p>
+              <p>Dev lecturer login: <span className="font-mono">{lastLaunch.dev_credentials.lecturer_login_id}</span></p>
+              <p>Password (both): <span className="font-mono">{lastLaunch.dev_credentials.password}</span></p>
+              <p className="mt-1">Session #{lastLaunch.session_id} · Exam #{lastLaunch.exam_id}</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/frontend/app/exam/page.tsx
+++ b/frontend/app/exam/page.tsx
@@ -79,6 +79,17 @@ export default function ExamPage() {
   const [accessChecked, setAccessChecked] = useState(false)
   const [terminatedReason, setTerminatedReason] = useState<string | null>(null)
   const [manualWarning, setManualWarning] = useState<string | null>(null)
+  // Exam Lab (see /exam-lab) may launch this page in mock-monitoring mode to
+  // skip camera/AI-socket setup for fast local iteration on the exam UI
+  // itself. Gated on a build-time flag that is never set in production
+  // builds, so this is inert outside local dev regardless of localStorage
+  // contents - it never touches auth, session, or identity_verified checks,
+  // which stay fully server-enforced (see the access-check effect below).
+  const [mockMonitoring] = useState(() => {
+    if (typeof window === "undefined") return false
+    if (process.env.NEXT_PUBLIC_ENABLE_DEV_TOOLS !== "true") return false
+    return localStorage.getItem("exam_lab_mock_monitoring") === "true"
+  })
   const { devtoolsLikelyOpen } = useBrowserLockdown({
     onBlockedAction: message => setSecurityAlert(message),
   })
@@ -382,12 +393,22 @@ export default function ExamPage() {
   }, [])
 
   useEffect(() => {
+    if (mockMonitoring) return
     void startExamCamera()
 
     return () => {
       stopExamCameraStream()
     }
-  }, [])
+  }, [mockMonitoring])
+
+  // Mock monitoring never sets examCameraReady, so neither the socket
+  // effect below nor the calibration failsafe (both gated on
+  // examCameraReady) would ever fire - calibrate immediately instead so the
+  // exam timer isn't stuck waiting on a camera that will never start.
+  useEffect(() => {
+    if (!mockMonitoring || !sessionId) return
+    setMonitoringCalibrated(true)
+  }, [mockMonitoring, sessionId])
 
   async function submitSessionToServer() {
     if (!sessionId) return
@@ -679,8 +700,8 @@ export default function ExamPage() {
               type="button"
               className="hidden items-center gap-1.5 rounded-md border border-emerald-200 bg-emerald-50 px-2.5 py-1 text-[11px] font-medium text-emerald-700 dark:border-emerald-900/60 dark:bg-emerald-950/30 dark:text-emerald-300 sm:flex"
             >
-              <span className={cn("h-1.5 w-1.5 rounded-full", socketConnected ? "bg-emerald-500" : "bg-amber-400")} />
-              {socketConnected ? "Monitoring" : "Connecting"}
+              <span className={cn("h-1.5 w-1.5 rounded-full", mockMonitoring ? "bg-sky-500" : socketConnected ? "bg-emerald-500" : "bg-amber-400")} />
+              {mockMonitoring ? "Mock" : socketConnected ? "Monitoring" : "Connecting"}
             </button>
             <button
               onClick={openSubmitConfirm}
@@ -909,7 +930,7 @@ export default function ExamPage() {
               />
             ) : (
               <p className="px-2 text-center text-[10px] font-medium text-zinc-300">
-                {examCameraError ?? "Starting camera..."}
+                {mockMonitoring ? "Mock monitoring active (Exam Lab) — camera disabled" : (examCameraError ?? "Starting camera...")}
               </p>
             )}
           </div>


### PR DESCRIPTION
## Summary
- Adds server-side-gated dev bootstrap endpoints (`backend/app/devtools`) that seed a deterministic dev lecturer, dev student, exam, questions, and an already-verified active `ExamSession` through the real tables — the actual `GET /sessions/:id/status` check still runs unmodified, so nothing is bypassed, just pre-seeded honestly.
- Only reachable when the backend has **both** `ENABLE_DEV_TOOLS=true` and `FLASK_ENV=development`; `docker-compose.api-prod.yml` sets neither, so it cannot exist in production through that path.
- Adds a standalone `/exam-lab` launcher page that reuses the real `/exam` page (no duplicated UI) plus an opt-in mock-monitoring toggle for iterating on the exam UI without a camera/AI socket.
- Adds `docs/exam-lab-local-testing.md`, a local test guide covering Docker startup, health checks, normal flow, Exam Lab flow, submission, timeout, autosave, tab-switch, camera-permission failure, AI events, and lecturer warn/terminate.
- Also carries over `5cf8b01` ("Weight gaze evidence by direction") from the `109` base branch this was branched from — that commit isn't on `main` yet either.

## Test plan
- [x] `backend/tests` — all 22 existing pytest tests pass unchanged
- [x] Confirmed the devtools blueprint 404s when `ENABLE_DEV_TOOLS` is unset, and also when set `true` without `FLASK_ENV=development` (double-gate holds)
- [x] Ran the full flow against a real Postgres instance: bootstrap → reset (idempotent) → `/exam` loads the real seeded question with `identity_verified` genuinely `true` server-side → autosave → submit → lecturer warn/terminate → post-terminate submit correctly rejected (409)
- [x] Frontend `tsc --noEmit`, `next build`, and `eslint` all clean (no new errors, only pre-existing warning patterns)
- [x] Verified in the browser pane that `/exam-lab` → Mock Monitoring launches straight into the real `/exam` page with the timer already running (no camera wait)

🤖 Generated with [Claude Code](https://claude.com/claude-code)