### PR TITLE
Fix Socket.IO connections failing when AI service is behind a URL path prefix

### DIFF
--- a/frontend/app/exam/page.tsx
+++ b/frontend/app/exam/page.tsx
@@ -7,7 +7,7 @@ import { io, type Socket } from "socket.io-client"
 import { cn } from "@/lib/utils"
 import { useBrowserLockdown } from "@/hooks/use-browser-lockdown"
 import { Calculator } from "@/components/calculator"
-import { getApiPath } from "@/lib/api-url"
+import { getApiPath, getSocketConnection } from "@/lib/api-url"
 import { ThemeToggle } from "@/components/theme-toggle"
 
 type LiveQuestion = {
@@ -583,8 +583,8 @@ export default function ExamPage() {
       try {
         if (cancelled) return
 
-        const wsUrl = process.env.NEXT_PUBLIC_WS_URL || "http://localhost:8000"
-        socket = io(wsUrl, { transports: ["websocket", "polling"] })
+        const { url: wsUrl, path: socketPath } = getSocketConnection()
+        socket = io(wsUrl, { path: socketPath, transports: ["websocket", "polling"] })
         socketRef.current = socket
 
         socket.on("connect", () => setSocketConnected(true))

--- a/frontend/app/lecturer/page.tsx
+++ b/frontend/app/lecturer/page.tsx
@@ -5,7 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation"
 import { AlertTriangle, BookOpen, Eye, EyeOff, KeyRound, LogOut, Plus, ShieldAlert, Users, X } from "lucide-react"
 import Link from "next/link"
 import { io } from "socket.io-client"
-import { getApiPath } from "@/lib/api-url"
+import { getApiPath, getSocketConnection } from "@/lib/api-url"
 import { cn } from "@/lib/utils"
 import { DashboardPanel, DashboardShell, MetricCard } from "@/components/dashboard-shell"
 import { StatusBadge } from "@/components/status-badge"
@@ -631,8 +631,8 @@ function LecturerDashboardInner() {
       return
     }
 
-    const wsUrl = process.env.NEXT_PUBLIC_WS_URL || "http://localhost:8000"
-    const socket = io(wsUrl, { transports: ["websocket", "polling"] })
+    const { url: wsUrl, path: socketPath } = getSocketConnection()
+    const socket = io(wsUrl, { path: socketPath, transports: ["websocket", "polling"] })
 
     socket.on("connect", () => {
       setLiveAlertsConnected(true)

--- a/frontend/lib/api-url.ts
+++ b/frontend/lib/api-url.ts
@@ -17,3 +17,26 @@ export function getApiPath(path: string) {
 
   return `/api${normalizedPath}`
 }
+
+// socket.io-client treats any path segment in the connection URL as a
+// namespace, not an HTTP path prefix - the actual handshake requests always
+// go to "<origin>/socket.io/" unless a `path` option is passed separately.
+// When NEXT_PUBLIC_WS_URL points at a host where the AI service is only
+// reachable under a path prefix (e.g. a reverse proxy exposing it at
+// "/ai/*" alongside the backend on the same domain, as in production),
+// passing the URL straight into io() silently connects to the wrong path
+// and the socket never opens. Split the configured URL into an origin and
+// a matching "<prefix>/socket.io/" path so both line up with how the
+// reverse proxy actually routes it.
+export function getSocketConnection() {
+  const configured = process.env.NEXT_PUBLIC_WS_URL?.trim()
+  const raw = configured || "http://localhost:8000"
+
+  try {
+    const parsed = new URL(raw)
+    const trimmedPath = parsed.pathname.replace(/\/+$/, "")
+    return { url: parsed.origin, path: `${trimmedPath}/socket.io/` }
+  } catch {
+    return { url: raw, path: "/socket.io/" }
+  }
+}


### PR DESCRIPTION
## Summary
- Production's reverse proxy exposes the AI service under `/ai/*` on the same domain as the backend (`proctoaibackend.neuraltale.com`), alongside a recent TLS/routing fix. `NEXT_PUBLIC_WS_URL` was updated to `https://proctoaibackend.neuraltale.com/ai` to match.
- That alone doesn't work: `socket.io-client` treats any path segment in the URL passed to `io()` as a **namespace**, not an HTTP path prefix — the actual handshake requests always go to `<origin>/socket.io/` regardless, unless a separate `path` option is passed. Both `frontend/app/exam/page.tsx` (student monitoring socket — also how `manual_warning`/`session_terminated` reach the student) and `frontend/app/lecturer/page.tsx` (live suspicious-activity feed) called `io(wsUrl, {...})` with no `path` option, so in production every socket connection was silently requesting the wrong path and never connecting.
- This is the direct cause of: the lecturer's live activity feed not updating, `Warn` not showing a popup on the student's screen, and `Terminate` not ending the student's session — all three ride this same socket.
- Adds `getSocketConnection()` to `frontend/lib/api-url.ts`, which splits the configured `NEXT_PUBLIC_WS_URL` into an origin and a matching `<prefix>/socket.io/` path, and uses it in both call sites. Local dev (URL has no path) is unaffected — still resolves to the default `/socket.io/`.

## Test plan
- [x] `tsc --noEmit` and `eslint` clean (no new errors, only pre-existing warning patterns)
- [x] Verified `getSocketConnection()`'s output directly for local (`http://127.0.0.1:8000`), docker-compose default (`ws://localhost:8000`), unset, and production (`https://proctoaibackend.neuraltale.com/ai`, with and without trailing slash) — production case correctly resolves to `origin=https://proctoaibackend.neuraltale.com`, `path=/ai/socket.io/`
- [x] Confirmed `https://proctoaibackend.neuraltale.com/ai/socket.io/?EIO=4&transport=polling` returns a valid Engine.IO handshake directly via curl — this is the exact path the fixed code now requests
- [ ] Needs a live retest after this deploys: lecturer live feed populating, Warn popup reaching the student, Terminate ending the student's session

🤖 Generated with [Claude Code](https://claude.com/claude-code)