### PR TITLE
Show Submitted/Terminated instead of a clickable Start Exam once a session is done

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -501,7 +501,27 @@ function StudentDashboardInner() {
                     <td className="pr-3">
                       {(() => {
                         const session = sessionByExamId.get(exam.exam_id)
-                        const started = Boolean(session && session.session_status !== "completed" && session.session_status !== "locked")
+                        // A session is single-attempt only (student_id+exam_id is
+                        // unique server-side) - once it's reached a terminal state,
+                        // POST /sessions/start will just 409 "cannot be resumed", so
+                        // the button must stop inviting another click rather than
+                        // surface that as a confusing error after the fact.
+                        const isTerminal = session
+                          ? session.session_status === "completed" ||
+                            session.session_status === "terminated" ||
+                            session.session_status === "locked"
+                          : false
+                        const started = Boolean(session && !isTerminal)
+                        if (isTerminal) {
+                          return (
+                            <button
+                              disabled
+                              className="cursor-not-allowed rounded-md bg-muted px-3 py-1.5 text-xs font-semibold text-muted-foreground"
+                            >
+                              {session?.session_status === "terminated" ? "Terminated" : "Submitted"}
+                            </button>
+                          )
+                        }
                         return (
                       <button onClick={() => void startExam(exam.exam_id)} className="rounded-md bg-[#1a2d5a] px-3 py-1.5 text-xs font-semibold text-white">
                         {started ? "Start New Attempt" : "Start Exam"}


### PR DESCRIPTION
## Summary
- `ExamSession` is single-attempt only (`UniqueConstraint("student_id", "exam_id")`), so once a session exists in any terminal state, `POST /sessions/start` always returns 409 "Exam session already exists and cannot be resumed." — but the dashboard's exam-list button only excluded `completed`/`locked` from its "in progress" check and still showed a normal, clickable "Start Exam" for a `completed` session, and a misleading "Start New Attempt" for a `terminated` one (missed entirely by the old exclusion set).
- `frontend/app/dashboard/page.tsx`: sessions with `session_status` of `completed`, `terminated`, or `locked` now render a disabled button labeled "Submitted" (or "Terminated" specifically) instead of one that invites a click that was always going to fail with a confusing error.
- The in-progress "Start New Attempt" path (active/pending sessions) is untouched — that's existing, separate, intentional behavior (forfeits and re-blocks a stale session), not part of this bug report.

## Test plan
- [x] `tsc --noEmit` clean
- [x] Verified live against a real local Postgres snapshot with mixed session states across many exams: a `completed` session correctly rendered "Submitted" and `disabled: true` (checked via JS), an `active` session correctly still rendered "Start New Attempt"
- [x] Submitted a fresh Exam Lab session live and confirmed its dashboard row flipped from "Start New Attempt" to a disabled "Submitted" immediately after submit

🤖 Generated with [Claude Code](https://claude.com/claude-code)