### PR TITLE
Lecturer Quick Shortcuts icons + accurate score/anomaly reporting

### DIFF
--- a/backend/app/exams/routes.py
+++ b/backend/app/exams/routes.py
@@ -586,6 +586,9 @@ def list_exam_students(exam_id):
         .order_by(User.full_name.asc())
         .all()
     )
+    total_marks = db.session.query(
+        db.func.coalesce(db.func.sum(Question.marks), 0)
+    ).filter(Question.exam_id == exam_id).scalar()
 
     return jsonify(
         {
@@ -598,6 +601,7 @@ def list_exam_students(exam_id):
                     "session_id": session.session_id,
                     "session_status": session.session_status,
                     "score": float(session.score) if session.score is not None else None,
+                    "total_marks": int(total_marks),
                     "warning_count": session.warning_count or 0,
                 }
                 for session, user in rows

--- a/backend/app/reports/routes.py
+++ b/backend/app/reports/routes.py
@@ -7,7 +7,7 @@ from flask_jwt_extended import get_jwt, get_jwt_identity, jwt_required
 
 from app.audit import log_audit
 from app.extensions import db
-from app.models import BehavioralLog, Exam, ExamSession, Report, User
+from app.models import BehavioralLog, Exam, ExamSession, Question, Report, User
 
 reports_bp = Blueprint("reports", __name__)
 
@@ -20,6 +20,21 @@ def _can_view_session(user_role, user_id, session_row, exam_row):
     return False
 
 
+def _total_marks_by_exam_id(exam_ids):
+    """Sum of Question.marks per exam_id, for rendering score as "X/Y"
+    instead of a bare number. Batched across all requested exam_ids rather
+    than queried per-row to avoid N+1 queries in the list endpoints."""
+    if not exam_ids:
+        return {}
+    rows = (
+        db.session.query(Question.exam_id, db.func.coalesce(db.func.sum(Question.marks), 0))
+        .filter(Question.exam_id.in_(set(exam_ids)))
+        .group_by(Question.exam_id)
+        .all()
+    )
+    return {exam_id: int(total) for exam_id, total in rows}
+
+
 def _build_report_snapshot(session_row):
     logs = BehavioralLog.query.filter_by(session_id=session_row.session_id).all()
     counts = {
@@ -28,6 +43,12 @@ def _build_report_snapshot(session_row):
         "tab_switch": 0,
         "face_absent": 0,
         "multiple_faces": 0,
+        # Previously omitted here despite incrementing warning_count in
+        # log_event() - meant total_anomalies could silently undercount
+        # relative to warning_count with no visible reason why. Counted here
+        # too now so the two numbers only ever diverge for the one reason
+        # that's actually meaningful: a lecturer's own manual warning.
+        "identity_mismatch": 0,
     }
     for log in logs:
         if log.event_type in counts:
@@ -70,18 +91,24 @@ def get_report(session_id):
     counts, total_anomalies, risk_level, logs = _build_report_snapshot(session_row)
     report = Report.query.filter_by(session_id=session_row.session_id).first()
     if not report:
-        report = Report(
-            session_id=session_row.session_id,
-            gaze_away_count=counts["gaze_away"],
-            head_turned_count=counts["head_turned"],
-            tab_switch_count=counts["tab_switch"],
-            face_absent_count=counts["face_absent"],
-            multiple_faces_count=counts["multiple_faces"],
-            total_anomalies=total_anomalies,
-            risk_level=risk_level,
-        )
+        report = Report(session_id=session_row.session_id)
         db.session.add(report)
-        db.session.commit()
+    # Always refresh from the live snapshot rather than only writing this
+    # row once - a session's logs can keep growing after the first time
+    # anyone opens its report, and a write-once cache would silently freeze
+    # these counts at whatever they were on that first view (confirmed: this
+    # produced a response where identity_mismatch_count, computed live below,
+    # didn't agree with the stale cached total_anomalies it should sum into).
+    report.gaze_away_count = counts["gaze_away"]
+    report.head_turned_count = counts["head_turned"]
+    report.tab_switch_count = counts["tab_switch"]
+    report.face_absent_count = counts["face_absent"]
+    report.multiple_faces_count = counts["multiple_faces"]
+    report.total_anomalies = total_anomalies
+    report.risk_level = risk_level
+    db.session.commit()
+
+    total_marks = _total_marks_by_exam_id([exam_row.exam_id]).get(exam_row.exam_id, 0)
 
     return (
         jsonify(
@@ -104,9 +131,11 @@ def get_report(session_id):
                     "tab_switch_count": report.tab_switch_count,
                     "face_absent_count": report.face_absent_count,
                     "multiple_faces_count": report.multiple_faces_count,
+                    "identity_mismatch_count": counts["identity_mismatch"],
                     "total_anomalies": report.total_anomalies,
                     "risk_level": report.risk_level,
                     "score": float(session_row.score) if session_row.score is not None else None,
+                    "total_marks": total_marks,
                     "warning_count": session_row.warning_count or 0,
                     "session_status": session_row.session_status,
                     "logs": [
@@ -205,6 +234,8 @@ def my_reports():
         .all()
     )
 
+    total_marks_by_exam = _total_marks_by_exam_id([exam_row.exam_id for _, exam_row in rows])
+
     payload = []
     for session_row, exam_row in rows:
         counts, total_anomalies, risk_level, _ = _build_report_snapshot(session_row)
@@ -215,6 +246,7 @@ def my_reports():
                 "exam_title": exam_row.title,
                 "course_code": exam_row.course_code,
                 "score": float(session_row.score) if session_row.score is not None else None,
+                "total_marks": total_marks_by_exam.get(exam_row.exam_id, 0),
                 "warning_count": session_row.warning_count or 0,
                 "risk_level": risk_level,
                 "total_anomalies": total_anomalies,
@@ -223,6 +255,7 @@ def my_reports():
                 "tab_switch_count": counts["tab_switch"],
                 "face_absent_count": counts["face_absent"],
                 "multiple_faces_count": counts["multiple_faces"],
+                "identity_mismatch_count": counts["identity_mismatch"],
                 "session_status": session_row.session_status,
             }
         )
@@ -247,6 +280,7 @@ def export_all_reports():
     if user_role == "lecturer":
         query = query.filter(Exam.lecturer_id == user_id)
     rows = query.order_by(Exam.exam_id, ExamSession.session_id).all()
+    total_marks_by_exam = _total_marks_by_exam_id([exam_row.exam_id for _, exam_row, _ in rows])
 
     output = io.StringIO()
     writer = csv.writer(output)
@@ -259,6 +293,7 @@ def export_all_reports():
             "student_name",
             "reg_number",
             "score",
+            "total_marks",
             "warning_count",
             "risk_level",
             "status",
@@ -276,6 +311,7 @@ def export_all_reports():
                 user_row.full_name,
                 user_row.reg_number,
                 float(session_row.score or 0),
+                total_marks_by_exam.get(exam_row.exam_id, 0),
                 session_row.warning_count,
                 risk_level,
                 session_row.session_status,
@@ -312,6 +348,7 @@ def export_exam_reports(exam_id):
         .filter(ExamSession.exam_id == exam_id)
         .all()
     )
+    total_marks = _total_marks_by_exam_id([exam_id]).get(exam_id, 0)
 
     output = io.StringIO()
     writer = csv.writer(output)
@@ -321,6 +358,7 @@ def export_exam_reports(exam_id):
             "student_name",
             "reg_number",
             "score",
+            "total_marks",
             "warning_count",
             "risk_level",
             "status",
@@ -335,6 +373,7 @@ def export_exam_reports(exam_id):
                 user_row.full_name,
                 user_row.reg_number,
                 float(session_row.score or 0),
+                total_marks,
                 session_row.warning_count,
                 risk_level if total_anomalies > 0 else "low",
                 session_row.session_status,

--- a/backend/app/sessions/routes.py
+++ b/backend/app/sessions/routes.py
@@ -659,6 +659,17 @@ def list_sessions():
         return jsonify({"error": {"message": "Forbidden"}}), 403
     sessions = sessions.all()
 
+    exam_ids = {exam.exam_id for _, exam, _ in sessions}
+    total_marks_by_exam = {}
+    if exam_ids:
+        for exam_id, total in (
+            db.session.query(Question.exam_id, db.func.coalesce(db.func.sum(Question.marks), 0))
+            .filter(Question.exam_id.in_(exam_ids))
+            .group_by(Question.exam_id)
+            .all()
+        ):
+            total_marks_by_exam[exam_id] = int(total)
+
     payload = []
     for session, exam, student in sessions:
         if session.warning_count >= 3:
@@ -680,6 +691,7 @@ def list_sessions():
                 "scheduled_at": exam.scheduled_at.isoformat() if exam.scheduled_at else None,
                 "session_status": session.session_status,
                 "score": float(session.score) if session.score is not None else None,
+                "total_marks": total_marks_by_exam.get(exam.exam_id, 0),
                 "warning_count": session.warning_count,
                 "risk_level": risk_level,
             }

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -48,10 +48,34 @@ type MyReportRow = {
   exam_title: string
   course_code: string
   score?: number | null
+  total_marks: number
   warning_count: number
   risk_level: string
   total_anomalies: number
+  gaze_away_count: number
+  head_turned_count: number
+  tab_switch_count: number
+  face_absent_count: number
+  multiple_faces_count: number
+  identity_mismatch_count: number
   session_status: string
+}
+
+const ANOMALY_TYPE_LABELS: { key: keyof MyReportRow; label: string }[] = [
+  { key: "gaze_away_count", label: "Gaze" },
+  { key: "head_turned_count", label: "Head Turn" },
+  { key: "face_absent_count", label: "Face Missing" },
+  { key: "multiple_faces_count", label: "Multiple Faces" },
+  { key: "tab_switch_count", label: "Tab Switch" },
+  { key: "identity_mismatch_count", label: "Identity Mismatch" },
+]
+
+function formatAnomalyBreakdown(row: MyReportRow): string {
+  const parts = ANOMALY_TYPE_LABELS
+    .map(({ key, label }) => ({ label, count: row[key] as number }))
+    .filter((entry) => entry.count > 0)
+    .map((entry) => `${entry.label} ×${entry.count}`)
+  return parts.length > 0 ? parts.join(", ") : "None"
 }
 
 const FALLBACK_DEGREE_PROGRAM_OPTIONS = [
@@ -539,7 +563,7 @@ function StudentDashboardInner() {
       ) : null}
 
       {tab === "sessions" ? (
-        <DashboardPanel title="Sessions & Reports">
+        <DashboardPanel title="Sessions & Reports" subtitle="Warnings is the total flagged count (including any lecturer-sent warning); Anomalies breaks down what was actually detected.">
           <div className="overflow-x-auto rounded-xl border border-border">
             <table className="w-full text-sm">
               <thead>
@@ -559,10 +583,10 @@ function StudentDashboardInner() {
                     <td className="py-2 pl-3">{r.exam_title}</td>
                     <td>{r.course_code}</td>
                     <td><StatusBadge value={r.session_status} /></td>
-                    <td>{r.score ?? "-"}</td>
+                    <td>{r.score != null ? `${r.score}/${r.total_marks}` : "-"}</td>
                     <td>{r.warning_count}</td>
                     <td><StatusBadge value={r.risk_level} /></td>
-                    <td>{r.total_anomalies}</td>
+                    <td className="max-w-[220px] text-xs text-muted-foreground">{formatAnomalyBreakdown(r)}</td>
                   </tr>
                 ))}
                 {reports.length === 0 ? <tr><td colSpan={7} className="py-3 pl-3 text-muted-foreground">No sessions yet.</td></tr> : null}

--- a/frontend/app/lecturer/page.tsx
+++ b/frontend/app/lecturer/page.tsx
@@ -2,7 +2,7 @@
 
 import { Suspense, useEffect, useMemo, useRef, useState } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
-import { AlertTriangle, Eye, EyeOff, KeyRound, LogOut, ShieldAlert, Users, X } from "lucide-react"
+import { AlertTriangle, BookOpenCheck, ClipboardList, Eye, EyeOff, FileQuestion, KeyRound, LogOut, ShieldAlert, UserCircle2, Users, X } from "lucide-react"
 import Link from "next/link"
 import { io } from "socket.io-client"
 import { getApiPath, getSocketConnection } from "@/lib/api-url"
@@ -69,6 +69,7 @@ type StudentRow = {
   email: string
   session_status: string
   score?: number | null
+  total_marks: number
   warning_count: number
 }
 
@@ -82,6 +83,7 @@ type SessionResultRow = {
   course_code: string
   session_status: string
   score?: number | null
+  total_marks: number
   warning_count: number
   risk_level: string
 }
@@ -117,9 +119,11 @@ type ReportDetail = {
   tab_switch_count: number
   face_absent_count: number
   multiple_faces_count: number
+  identity_mismatch_count: number
   total_anomalies: number
   risk_level: string
   score?: number | null
+  total_marks: number
   warning_count?: number
   session_status?: string
   logs: ReportLogEntry[]
@@ -964,6 +968,7 @@ function LecturerDashboardInner() {
       "exam_title",
       "status",
       "score",
+      "total_marks",
       "warning_count",
       "risk_level",
     ]
@@ -975,6 +980,7 @@ function LecturerDashboardInner() {
       row.exam_title,
       row.session_status,
       row.score ?? "",
+      row.total_marks,
       row.warning_count,
       row.risk_level,
     ])
@@ -1219,23 +1225,28 @@ function LecturerDashboardInner() {
         <DashboardPanel title="Quick Shortcuts" subtitle="Move quickly between lecturer workflows.">
           <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
             <Link href="/lecturer?tab=exams" className="rounded-xl border border-border bg-gradient-to-br from-blue-50 to-indigo-50 p-4 transition hover:shadow-md dark:from-slate-900 dark:to-slate-800">
-              <p className="text-sm font-semibold text-foreground">Exams</p>
+              <BookOpenCheck className="h-5 w-5 text-[#1a2d5a]" />
+              <p className="mt-2 text-sm font-semibold text-foreground">Exams</p>
               <p className="mt-1 text-xs text-muted-foreground">Create and manage exams.</p>
             </Link>
             <Link href="/lecturer?tab=questions" className="rounded-xl border border-border bg-gradient-to-br from-emerald-50 to-teal-50 p-4 transition hover:shadow-md dark:from-slate-900 dark:to-slate-800">
-              <p className="text-sm font-semibold text-foreground">Questions</p>
+              <FileQuestion className="h-5 w-5 text-emerald-700" />
+              <p className="mt-2 text-sm font-semibold text-foreground">Questions</p>
               <p className="mt-1 text-xs text-muted-foreground">Build question banks.</p>
             </Link>
             <Link href="/lecturer?tab=students" className="rounded-xl border border-border bg-gradient-to-br from-amber-50 to-orange-50 p-4 transition hover:shadow-md dark:from-slate-900 dark:to-slate-800">
-              <p className="text-sm font-semibold text-foreground">Students</p>
+              <Users className="h-5 w-5 text-amber-700" />
+              <p className="mt-2 text-sm font-semibold text-foreground">Students</p>
               <p className="mt-1 text-xs text-muted-foreground">View enrolled students.</p>
             </Link>
             <Link href="/lecturer?tab=results" className="rounded-xl border border-border bg-gradient-to-br from-violet-50 to-fuchsia-50 p-4 transition hover:shadow-md dark:from-slate-900 dark:to-slate-800">
-              <p className="text-sm font-semibold text-foreground">Sessions & Reports</p>
+              <ClipboardList className="h-5 w-5 text-violet-700" />
+              <p className="mt-2 text-sm font-semibold text-foreground">Sessions & Reports</p>
               <p className="mt-1 text-xs text-muted-foreground">Inspect outcomes and risk.</p>
             </Link>
             <Link href="/lecturer?tab=profile" className="rounded-xl border border-border bg-gradient-to-br from-slate-100 to-slate-200 p-4 transition hover:shadow-md dark:from-slate-900 dark:to-slate-800">
-              <p className="text-sm font-semibold text-foreground">Profile</p>
+              <UserCircle2 className="h-5 w-5 text-slate-700" />
+              <p className="mt-2 text-sm font-semibold text-foreground">Profile</p>
               <p className="mt-1 text-xs text-muted-foreground">Reset account password.</p>
             </Link>
           </div>
@@ -1481,7 +1492,7 @@ function LecturerDashboardInner() {
                     <td>{s.registration_number}</td>
                     <td>{s.email}</td>
                     <td><StatusBadge value={s.session_status} /></td>
-                    <td>{s.score ?? "-"}</td>
+                    <td>{s.score != null ? `${s.score}/${s.total_marks}` : "-"}</td>
                     <td>{s.warning_count}</td>
                   </tr>
                 ))}
@@ -1751,7 +1762,7 @@ function LecturerDashboardInner() {
                     <td>{row.course_code}</td>
                     <td>{row.exam_title}</td>
                     <td><StatusBadge value={row.session_status} /></td>
-                    <td>{row.score ?? "-"}</td>
+                    <td>{row.score != null ? `${row.score}/${row.total_marks}` : "-"}</td>
                     <td>{row.warning_count}</td>
                     <td><StatusBadge value={row.risk_level} /></td>
                     <td>
@@ -1987,7 +1998,9 @@ function LecturerDashboardInner() {
 
           <div className="mt-3 grid grid-cols-3 gap-2">
             <div className="rounded-md border border-border bg-background p-3 text-center">
-              <p className="text-xl font-semibold text-foreground">{viewingReport.score ?? "-"}</p>
+              <p className="text-xl font-semibold text-foreground">
+                {viewingReport.score != null ? `${viewingReport.score}/${viewingReport.total_marks}` : "-"}
+              </p>
               <p className="text-xs text-muted-foreground">Score</p>
             </div>
             <div className="rounded-md border border-border bg-background p-3 text-center">
@@ -2007,6 +2020,7 @@ function LecturerDashboardInner() {
               { label: "Tab Switch", value: viewingReport.tab_switch_count },
               { label: "Face Absent", value: viewingReport.face_absent_count },
               { label: "Multiple Faces", value: viewingReport.multiple_faces_count },
+              { label: "Identity Mismatch", value: viewingReport.identity_mismatch_count },
             ].map((stat) => (
               <div key={stat.label} className="rounded-md border border-border bg-background p-3 text-center">
                 <p className="text-xl font-semibold text-foreground">{stat.value}</p>
@@ -2041,6 +2055,7 @@ function LecturerDashboardInner() {
                     course_code: viewingReport.exam.course_code,
                     session_status: viewingReport.session_status || "active",
                     score: viewingReport.score ?? null,
+                    total_marks: viewingReport.total_marks,
                     warning_count: viewingReport.warning_count ?? 0,
                     risk_level: viewingReport.risk_level,
                   }


### PR DESCRIPTION
## Summary
- Lecturer dashboard's Quick Shortcuts cards now have icons matching the student dashboard's style (same icon reused for Exams/Sessions & Reports/Profile since those cards mean the same thing on both dashboards; new icons picked for the lecturer-only Questions/Students cards).
- Fixed the student's (and lecturer's) Sessions & Reports table showing "Warnings" and "Anomalies" as identical numbers with no explanation — `total_anomalies` silently excluded `identity_mismatch` while `warning_count` included it. Anomalies now shows an actual per-type breakdown instead of a duplicate total.
- Fixed a real staleness bug this exposed: `get_report()`'s cached `Report` row was only ever written once per session, so its counts could silently diverge from live data on repeat views.
- Score now renders as `X/Y` (e.g. `1/7`) everywhere it's shown, using each exam's actual total marks, instead of a bare number with no denominator.

## Test plan
- [x] Full backend suite (28 passed)
- [x] Frontend `tsc --noEmit` and `eslint` clean
- [x] End-to-end verification against real migrated data in the local production-mirror DB: confirmed `total_marks` matches a direct SQL sum, and confirmed the report response's `total_anomalies` now agrees with the sum of its own per-type breakdown fields (previously inconsistent within the same response)
- [ ] Manual click-through in browser by reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)