### PR TITLE
Fix login brute-force lockout and add missing FK indexes

### DIFF
--- a/backend/app/auth/routes.py
+++ b/backend/app/auth/routes.py
@@ -13,12 +13,10 @@ from sqlalchemy import or_
 
 from app.extensions import db
 from app.audit import log_audit
-from app.models import FacialImage, User
+from app.models import FacialImage, LoginAttempt, User
 
 auth_bp = Blueprint("auth", __name__)
 
-# Lightweight in-process brute-force guard.
-_LOGIN_ATTEMPTS = {}
 _MAX_FAILED_ATTEMPTS = 5
 _LOCKOUT_MINUTES = 10
 
@@ -106,30 +104,39 @@ def _ip_from_request() -> str:
 
 def _is_locked_out(login_id: str, ip: str) -> tuple[bool, int]:
     key = _attempt_key(login_id, ip)
-    entry = _LOGIN_ATTEMPTS.get(key)
-    if not entry:
+    entry = db.session.get(LoginAttempt, key)
+    if not entry or not entry.lockout_until:
         return False, 0
-    lockout_until = entry.get("lockout_until")
-    if lockout_until and datetime.utcnow() < lockout_until:
-        remaining = int((lockout_until - datetime.utcnow()).total_seconds())
+    now = datetime.utcnow()
+    if now < entry.lockout_until:
+        remaining = int((entry.lockout_until - now).total_seconds())
         return True, max(1, remaining)
-    if lockout_until and datetime.utcnow() >= lockout_until:
-        _LOGIN_ATTEMPTS.pop(key, None)
+    # Lockout has expired - clear it here rather than letting it sit forever,
+    # since nothing else sweeps stale rows out of this table.
+    db.session.delete(entry)
+    db.session.commit()
     return False, 0
 
 
 def _register_failed_attempt(login_id: str, ip: str) -> None:
     key = _attempt_key(login_id, ip)
-    entry = _LOGIN_ATTEMPTS.get(key) or {"count": 0, "lockout_until": None, "last_attempt": None}
-    entry["count"] += 1
-    entry["last_attempt"] = datetime.utcnow()
-    if entry["count"] >= _MAX_FAILED_ATTEMPTS:
-        entry["lockout_until"] = datetime.utcnow() + timedelta(minutes=_LOCKOUT_MINUTES)
-    _LOGIN_ATTEMPTS[key] = entry
+    entry = db.session.get(LoginAttempt, key)
+    if not entry:
+        entry = LoginAttempt(attempt_key=key, failed_count=0)
+        db.session.add(entry)
+    entry.failed_count += 1
+    entry.last_attempt_at = datetime.utcnow()
+    if entry.failed_count >= _MAX_FAILED_ATTEMPTS:
+        entry.lockout_until = datetime.utcnow() + timedelta(minutes=_LOCKOUT_MINUTES)
+    # Caller (login()) commits alongside its audit-log write.
 
 
 def _clear_attempts(login_id: str, ip: str) -> None:
-    _LOGIN_ATTEMPTS.pop(_attempt_key(login_id, ip), None)
+    key = _attempt_key(login_id, ip)
+    entry = db.session.get(LoginAttempt, key)
+    if entry:
+        db.session.delete(entry)
+    # Caller (login()) commits alongside its audit-log write.
 
 
 @auth_bp.post("/register")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -6,6 +6,7 @@ from app.models.exam import Exam, exam_programs
 from app.models.exam_session import ExamSession
 from app.models.exam_student_assignment import ExamStudentAssignment
 from app.models.facial_image import FacialImage
+from app.models.login_attempt import LoginAttempt
 from app.models.question import Question
 from app.models.report import Report
 from app.models.session_answer import SessionAnswer
@@ -25,4 +26,5 @@ __all__ = [
     "BehavioralLog",
     "Report",
     "SessionAnswer",
+    "LoginAttempt",
 ]

--- a/backend/app/models/login_attempt.py
+++ b/backend/app/models/login_attempt.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+
+from app.extensions import db
+
+
+class LoginAttempt(db.Model):
+    """Shared, DB-backed brute-force guard for /auth/login.
+
+    Replaces an in-process dict that gave every gunicorn worker its own
+    independent view of failed attempts - under multiple workers, an
+    attacker's requests get distributed across processes that don't know
+    about each other's lockouts, roughly doubling (per extra worker) the
+    attempts available before a lockout actually blocks every worker.
+    """
+
+    __tablename__ = "login_attempts"
+
+    attempt_key = db.Column(db.String(320), primary_key=True)
+    failed_count = db.Column(db.Integer, nullable=False, default=0)
+    lockout_until = db.Column(db.DateTime, nullable=True)
+    last_attempt_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)

--- a/backend/migrations/versions/0014_add_missing_foreign_key_indexes.py
+++ b/backend/migrations/versions/0014_add_missing_foreign_key_indexes.py
@@ -1,0 +1,38 @@
+"""add missing indexes on hot foreign-key columns
+
+Revision ID: 0014_add_missing_foreign_key_indexes
+Revises: 0013_add_session_termination_and_log_review
+Create Date: 2026-08-04 06:00:00.000000
+
+facial_images.user_id, questions.exam_id and exams.lecturer_id had no
+index at all. exam_sessions has a composite unique index on
+(student_id, exam_id), which Postgres can use for student_id-only lookups
+(leftmost prefix) but not for the exam_id-only lookups several endpoints
+do (e.g. list_exam_students) - so exam_id gets its own index too.
+
+facial_images.user_id matters most in practice: it's read on every ~8s
+periodic identity recheck for every active session, feeding directly into
+the documented "<3s identity verification" latency target.
+"""
+
+from alembic import op
+
+
+revision = "0014_add_missing_foreign_key_indexes"
+down_revision = "0013_add_session_termination_and_log_review"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index("idx_facial_images_user", "facial_images", ["user_id"])
+    op.create_index("idx_questions_exam", "questions", ["exam_id"])
+    op.create_index("idx_exams_lecturer", "exams", ["lecturer_id"])
+    op.create_index("idx_exam_sessions_exam", "exam_sessions", ["exam_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_exam_sessions_exam", table_name="exam_sessions")
+    op.drop_index("idx_exams_lecturer", table_name="exams")
+    op.drop_index("idx_questions_exam", table_name="questions")
+    op.drop_index("idx_facial_images_user", table_name="facial_images")

--- a/backend/migrations/versions/0015_add_login_attempts.py
+++ b/backend/migrations/versions/0015_add_login_attempts.py
@@ -1,0 +1,35 @@
+"""add login_attempts table for a shared, DB-backed brute-force guard
+
+Revision ID: 0015_add_login_attempts
+Revises: 0014_add_missing_foreign_key_indexes
+Create Date: 2026-08-04 06:05:00.000000
+
+Replaces the in-process _LOGIN_ATTEMPTS dict in app/auth/routes.py, which
+gave every gunicorn worker (production runs --workers 2) its own
+independent view of failed attempts - an attacker's requests get
+distributed across processes that don't share a lockout, and the dict
+itself grew without bound since nothing ever swept old entries.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0015_add_login_attempts"
+down_revision = "0014_add_missing_foreign_key_indexes"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "login_attempts",
+        sa.Column("attempt_key", sa.String(length=320), primary_key=True),
+        sa.Column("failed_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("lockout_until", sa.DateTime(), nullable=True),
+        sa.Column("last_attempt_at", sa.DateTime(), nullable=False, server_default=sa.text("now()")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("login_attempts")

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,6 +1,3 @@
-from app.auth import routes as auth_routes
-
-
 def test_register_and_login_success(client):
     register_payload = {
         "name": "Jane Doe",
@@ -100,30 +97,87 @@ def test_admin_provisions_instructor_credentials(client):
 
 
 def test_login_bruteforce_lockout(client):
-    auth_routes._LOGIN_ATTEMPTS.clear()
-    try:
-        client.post(
-            "/api/auth/register",
-            json={
-                "name": "Lockout Target",
-                "registration_number": "T22-03-33333",
-                "password": "CorrectPassword123",
-            },
-        )
+    client.post(
+        "/api/auth/register",
+        json={
+            "name": "Lockout Target",
+            "registration_number": "T22-03-33333",
+            "password": "CorrectPassword123",
+        },
+    )
 
-        for _ in range(5):
-            failed = client.post(
-                "/api/auth/login",
-                json={"registration_number": "T22-03-33333", "password": "WrongPassword123"},
-            )
-            assert failed.status_code == 401
-
-        locked = client.post(
+    for _ in range(5):
+        failed = client.post(
             "/api/auth/login",
-            json={"registration_number": "T22-03-33333", "password": "CorrectPassword123"},
+            json={"registration_number": "T22-03-33333", "password": "WrongPassword123"},
         )
-        assert locked.status_code == 429
-        payload = locked.get_json()
-        assert "Too many failed attempts" in payload["error"]["message"]
-    finally:
-        auth_routes._LOGIN_ATTEMPTS.clear()
+        assert failed.status_code == 401
+
+    locked = client.post(
+        "/api/auth/login",
+        json={"registration_number": "T22-03-33333", "password": "CorrectPassword123"},
+    )
+    assert locked.status_code == 429
+    payload = locked.get_json()
+    assert "Too many failed attempts" in payload["error"]["message"]
+
+
+def test_login_bruteforce_lockout_shared_across_requests(client, app):
+    """The lockout must be visible from a second, independent request context
+    (e.g. a different gunicorn worker in production) - not just reachable
+    because a Python module still holds the state in memory. Directly
+    exercises the DB-backed LoginAttempt row rather than trusting in-process
+    state, since that in-process trust is exactly what broke this guard
+    under multiple workers before."""
+    from app.extensions import db
+    from app.models import LoginAttempt
+
+    client.post(
+        "/api/auth/register",
+        json={
+            "name": "Lockout Target 2",
+            "registration_number": "T22-03-33334",
+            "password": "CorrectPassword123",
+        },
+    )
+    for _ in range(5):
+        client.post(
+            "/api/auth/login",
+            json={"registration_number": "T22-03-33334", "password": "WrongPassword123"},
+        )
+
+    with app.app_context():
+        rows = LoginAttempt.query.all()
+        assert len(rows) == 1
+        assert rows[0].failed_count == 5
+        assert rows[0].lockout_until is not None
+
+    locked = client.post(
+        "/api/auth/login",
+        json={"registration_number": "T22-03-33334", "password": "CorrectPassword123"},
+    )
+    assert locked.status_code == 429
+
+
+def test_login_success_clears_attempt_row(client):
+    client.post(
+        "/api/auth/register",
+        json={
+            "name": "Clears Attempts",
+            "registration_number": "T22-03-33335",
+            "password": "CorrectPassword123",
+        },
+    )
+    client.post(
+        "/api/auth/login",
+        json={"registration_number": "T22-03-33335", "password": "WrongPassword123"},
+    )
+    ok = client.post(
+        "/api/auth/login",
+        json={"registration_number": "T22-03-33335", "password": "CorrectPassword123"},
+    )
+    assert ok.status_code == 200
+
+    from app.models import LoginAttempt
+
+    assert LoginAttempt.query.count() == 0


### PR DESCRIPTION
## Summary
From a broader flow/performance audit, fixes the two items prioritized for now:

- **Login brute-force lockout was ineffective in production.** `_LOGIN_ATTEMPTS` was a plain in-process dict, but production runs `gunicorn --workers 2` — two processes, each with its own view of failed attempts. An attacker's requests get load-balanced across both, roughly halving the effective threshold, and even once one worker locks out, ~50% of requests still got through via the other. The dict also grew without bound (nothing ever swept old entries). Replaced with a `login_attempts` DB table, shared across every worker and self-bounding (a row is cleared the moment its lockout is checked post-expiry, or on next successful login).
- **Missing indexes on hot foreign-key columns.** `facial_images.user_id`, `questions.exam_id`, and `exams.lecturer_id` had none; `exam_sessions.exam_id`-only lookups couldn't use the existing composite unique index (`exam_id` isn't its leading column). `facial_images.user_id` matters most — it's read on every ~8s periodic identity recheck during every active session, feeding directly into the documented "<3s identity verification" latency target.

Two other items from the audit (single-worker AI service CPU bottleneck, stale face-embedding cache) were explicitly deferred — not urgent while testing with a small group of students.

## Test plan
- [x] Full backend suite (30 passed, including 2 new tests for the DB-backed lockout: one proving the lockout is visible via an independent DB read — the actual multi-worker scenario — and one proving success clears the row)
- [x] Migrations applied cleanly to the local production-mirror DB; all 4 indexes and the new table confirmed via `psql`
- [x] End-to-end verified against the *running* backend over real HTTP: 5 real failed logins produced a real `login_attempts` row and a 429 on the 6th attempt, confirmed via direct `psql` query (not just the test suite)
- [ ] Manual review by reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)