### PR TITLE
Never prompt lecturers/admins for camera access

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -442,6 +442,7 @@ function StudentDashboardInner() {
       appName="ProctorAI Student"
       title={STUDENT_TAB_TITLES[tab] || "Dashboard"}
       subtitle={`${me?.full_name || "-"} | ${me?.registration_number || "-"} | ${me?.department || "Course not set"}`}
+      requireCamera
       sidebarItems={[
         { label: "Dashboard", href: "/dashboard", active: tab === "dashboard" },
         { label: "Exams", href: "/dashboard?tab=exams", active: tab === "exams" },

--- a/frontend/components/dashboard-shell.tsx
+++ b/frontend/components/dashboard-shell.tsx
@@ -24,6 +24,10 @@ type DashboardShellProps = {
   avatarImageUrl?: string | null
   isExiting?: boolean
   exitMessage?: string
+  // Only students ever go through camera-based identity verification/live
+  // monitoring - lecturers and admins should never be asked for camera
+  // access, so this defaults to false and only the student dashboard opts in.
+  requireCamera?: boolean
   children: ReactNode
 }
 
@@ -45,6 +49,7 @@ export function DashboardShell({
   avatarImageUrl,
   isExiting = false,
   exitMessage = "Signing out...",
+  requireCamera = false,
   children,
 }: DashboardShellProps) {
   const router = useRouter()
@@ -160,13 +165,14 @@ export function DashboardShell({
   }, [router, isExiting, idleWarningOpen])
 
   useEffect(() => {
+    if (!requireCamera) return
     const token = typeof window !== "undefined" ? localStorage.getItem("token") : null
     if (!token) return
     if (!window.isSecureContext) return
     if (!navigator.mediaDevices?.getUserMedia) return
     if (sessionStorage.getItem("camera_permission_prompted") === "1") return
     setCameraPromptOpen(true)
-  }, [])
+  }, [requireCamera])
 
   async function requestCameraPermission() {
     setCameraPromptError("")


### PR DESCRIPTION
## Summary
- `DashboardShell`'s "Enable Camera Access" prompt fired for any logged-in user on any page - it's shared by the student dashboard, the lecturer dashboard, and all 6 admin pages, and had no role check at all.
- Only students ever go through camera-based identity verification/live monitoring. Added a `requireCamera` prop (defaults `false`); only the student dashboard now passes it, so lecturers and admins are never asked.

## Test plan
- [x] Frontend `tsc --noEmit` and `eslint` clean
- [x] Confirmed only the student dashboard passes `requireCamera` now; lecturer and all admin pages use the `false` default
- [ ] Manual click-through in browser by reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)