### PR TITLE
Fix timestamp timezone display and false identity-mismatch alerts

### DIFF
--- a/ai-service/sockets/frame_handler.py
+++ b/ai-service/sockets/frame_handler.py
@@ -35,6 +35,18 @@ _lock = threading.Lock()
 _IDENTITY_RECHECK_SECONDS = float(os.getenv('IDENTITY_RECHECK_SECONDS', '8'))
 _IDENTITY_MISMATCH_CONFIRM_COUNT = int(os.getenv('IDENTITY_MISMATCH_CONFIRM_COUNT', '2'))
 
+# FaceNet embeddings are known to degrade badly under pose variation and on
+# partial/low-confidence face detections - comparing an off-angle or
+# partially-occluded frame against the frontal registered baseline produces
+# a genuinely lower similarity score that has nothing to do with identity.
+# Confirmed in production: looking away or having the head turned was
+# consistently misreported to lecturers as "Identity Mismatch Detected"
+# instead of the actual gaze_away/head_turned anomaly, since this check ran
+# regardless of pose and its confirmation cycle is faster in practice than
+# gaze/head's own persistence window. min face-detection confidence required
+# before trusting a crop enough to run identity comparison on it at all.
+_IDENTITY_CHECK_MIN_FACE_CONFIDENCE = float(os.getenv('IDENTITY_CHECK_MIN_FACE_CONFIDENCE', '0.8'))
+
 # Number of frames at the start of a session used to calibrate that
 # student's own neutral head pose, before any head_turned alert can fire.
 # A fixed global yaw/pitch threshold doesn't work across different real
@@ -280,8 +292,8 @@ def _check_identity_mismatch(session_id, img_bgr):
     if student_id is None:
         return False, None
 
-    face_crop, _ = detect_and_crop_face(img_bgr)
-    if face_crop is None:
+    face_crop, face_confidence = detect_and_crop_face(img_bgr)
+    if face_crop is None or face_confidence < _IDENTITY_CHECK_MIN_FACE_CONFIDENCE:
         return False, None
 
     try:
@@ -393,13 +405,21 @@ def register_handlers(socketio: SocketIO):
         # student adjusting their seat or glancing away while the camera is
         # still calibrating could rack up persistence toward a warning that
         # then fires the moment "Setting Up Monitoring" disappears.
+        gaze_evidence = _gaze_evidence(gaze)
+
+        # A turned head or an away gaze both put the face at an angle FaceNet
+        # wasn't trained to compare reliably against a frontal baseline -
+        # skip the identity check on those frames entirely so a pose-related
+        # anomaly gets attributed to gaze_away/head_turned instead of
+        # masquerading as a (false) identity mismatch. See
+        # _IDENTITY_CHECK_MIN_FACE_CONFIDENCE above for the same fix applied
+        # to partial/occluded face detections.
         identity_mismatch_confirmed = False
         identity_confidence = None
-        if not calibrating and face_count[0] == 1:
+        if not calibrating and face_count[0] == 1 and not head_alert and not gaze_evidence['is_away']:
             identity_mismatch_confirmed, identity_confidence = _check_identity_mismatch(session_id, img_bgr)
 
         anomalies = []
-        gaze_evidence = _gaze_evidence(gaze)
         if not calibrating:
             if gaze is None or face_count[0] == 0:
                 anomalies.append('face_absent')

--- a/ai-service/tests/test_frame_handler_identity_pose_gate.py
+++ b/ai-service/tests/test_frame_handler_identity_pose_gate.py
@@ -1,0 +1,130 @@
+import sys
+import os
+import base64
+
+import cv2
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from app import app, socketio
+import sockets.frame_handler as fh
+
+
+def _dummy_frame_base64():
+    img = np.zeros((240, 320, 3), dtype=np.uint8)
+    ok, buf = cv2.imencode('.jpg', img)
+    assert ok
+    return base64.b64encode(buf.tobytes()).decode('ascii')
+
+
+@pytest.fixture
+def socket_client(monkeypatch):
+    fh._anomaly_states.clear()
+    fh._warning_counts.clear()
+    fh._baseline_pose.clear()
+    fh._gaze_calibration.clear()
+    fh._identity_check_state.clear()
+    fh._session_student_id.clear()
+    app.config['TESTING'] = True
+    client = socketio.test_client(app)
+    yield client
+    client.disconnect()
+
+
+def _calibrate(client, session_id, frame_base64):
+    """Run a session through calibration with a neutral, on-screen gaze so
+    post-calibration frames are judged against a sane baseline."""
+    for _ in range(fh._HEAD_POSE_CALIBRATION_FRAMES):
+        client.emit('webcam_frame', {'session_id': session_id, 'frame_base64': frame_base64})
+        client.get_received()
+
+
+def test_identity_check_skipped_when_gaze_is_away(monkeypatch, socket_client):
+    """A face turned away from the camera produces genuinely unreliable
+    FaceNet embeddings against the frontal baseline - confirmed in
+    production, this used to let a plain "looked away" get reported to the
+    lecturer as "Identity Mismatch Detected" instead of gaze_away. The
+    identity check must not even run on these frames."""
+    calls = []
+    monkeypatch.setattr(fh, '_check_identity_mismatch', lambda session_id, img: calls.append(session_id) or (False, None))
+    monkeypatch.setattr(fh, 'estimate_head_pose', lambda img: {'yaw': -2.0, 'pitch': -10.0, 'roll': 0.0, 'alert': False})
+    monkeypatch.setattr(fh, 'count_faces', lambda img: 1)
+
+    frame_base64 = _dummy_frame_base64()
+    session_id = 'gaze-away-session'
+
+    monkeypatch.setattr(fh, 'estimate_gaze', lambda img: {'direction': 'Screen', 'confidence': 0.95, 'model_available': True})
+    _calibrate(socket_client, session_id, frame_base64)
+    assert calls == []  # nothing runs identity checks during calibration anyway
+
+    monkeypatch.setattr(fh, 'estimate_gaze', lambda img: {'direction': 'Down', 'confidence': 0.95, 'model_available': True})
+    socket_client.emit('webcam_frame', {'session_id': session_id, 'frame_base64': frame_base64})
+    socket_client.get_received()
+
+    assert calls == []
+
+
+def test_identity_check_skipped_when_head_is_turned(monkeypatch, socket_client):
+    """Same failure mode as the gaze-away case, but for a turned head -
+    should be attributed to head_turned, never identity_mismatch."""
+    calls = []
+    monkeypatch.setattr(fh, '_check_identity_mismatch', lambda session_id, img: calls.append(session_id) or (False, None))
+    monkeypatch.setattr(fh, 'count_faces', lambda img: 1)
+    monkeypatch.setattr(fh, 'estimate_gaze', lambda img: {'direction': 'Screen', 'confidence': 0.95, 'model_available': True})
+
+    frame_base64 = _dummy_frame_base64()
+    session_id = 'head-turned-session'
+
+    monkeypatch.setattr(fh, 'estimate_head_pose', lambda img: {'yaw': -2.0, 'pitch': -10.0, 'roll': 0.0, 'alert': False})
+    _calibrate(socket_client, session_id, frame_base64)
+    assert calls == []
+
+    monkeypatch.setattr(fh, 'estimate_head_pose', lambda img: {'yaw': 45.0, 'pitch': -10.0, 'roll': 0.0, 'alert': True})
+    socket_client.emit('webcam_frame', {'session_id': session_id, 'frame_base64': frame_base64})
+    socket_client.get_received()
+
+    assert calls == []
+
+
+def test_identity_check_still_runs_for_a_normal_frontal_frame(monkeypatch, socket_client):
+    """Regression guard: a student looking normally at the screen, post
+    calibration, must still get the periodic identity recheck exactly as
+    before this fix."""
+    calls = []
+    monkeypatch.setattr(fh, '_check_identity_mismatch', lambda session_id, img: calls.append(session_id) or (False, None))
+    monkeypatch.setattr(fh, 'estimate_head_pose', lambda img: {'yaw': -2.0, 'pitch': -10.0, 'roll': 0.0, 'alert': False})
+    monkeypatch.setattr(fh, 'count_faces', lambda img: 1)
+    monkeypatch.setattr(fh, 'estimate_gaze', lambda img: {'direction': 'Screen', 'confidence': 0.95, 'model_available': True})
+
+    frame_base64 = _dummy_frame_base64()
+    session_id = 'normal-session'
+    _calibrate(socket_client, session_id, frame_base64)
+    assert calls == []
+
+    socket_client.emit('webcam_frame', {'session_id': session_id, 'frame_base64': frame_base64})
+    socket_client.get_received()
+
+    assert calls == [session_id]
+
+
+def test_identity_check_skips_low_confidence_face_detection(monkeypatch):
+    """A partially-occluded or low-confidence face detection (e.g. a hand
+    partly covering the camera) shouldn't be trusted for identity
+    comparison either - same unreliable-embedding problem as an off-angle
+    face, just from a different cause."""
+    fh._identity_check_state.clear()
+    fh._session_student_id.clear()
+    monkeypatch.setattr(fh, '_resolve_student_id', lambda session_id: 42)
+    monkeypatch.setattr(fh, 'get_facenet', lambda: object())
+    monkeypatch.setattr(
+        fh, 'detect_and_crop_face',
+        lambda img: (np.zeros((10, 10, 3), dtype=np.uint8), 0.5),
+    )
+
+    img = np.zeros((240, 320, 3), dtype=np.uint8)
+    confirmed, confidence = fh._check_identity_mismatch('low-confidence-session', img)
+
+    assert confirmed is False
+    assert confidence is None

--- a/frontend/app/admin/credentials/page.tsx
+++ b/frontend/app/admin/credentials/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation"
 import { LogOut } from "lucide-react"
 import { DashboardPanel, DashboardShell } from "@/components/dashboard-shell"
 import { readGeneratedCredentials } from "@/lib/generated-credentials"
+import { formatDateTimeEAT } from "@/lib/format-time"
 
 export default function AdminCredentialsPage() {
   const router = useRouter()
@@ -97,7 +98,7 @@ export default function AdminCredentialsPage() {
             <tbody>
               {rows.map((row, idx) => (
                 <tr key={`${row.login_id}-${idx}`} className="border-b last:border-b-0">
-                  <td className="py-2 pl-3">{new Date(row.created_at).toLocaleString()}</td>
+                  <td className="py-2 pl-3">{formatDateTimeEAT(row.created_at)}</td>
                   <td>{row.full_name}</td>
                   <td>{row.role}</td>
                   <td className="font-mono">{row.login_id}</td>

--- a/frontend/app/admin/exams/page.tsx
+++ b/frontend/app/admin/exams/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react"
 import { useRouter } from "next/navigation"
 import { ClipboardList, LogOut } from "lucide-react"
 import { getApiPath } from "@/lib/api-url"
+import { formatDateTimeEAT } from "@/lib/format-time"
 import { DashboardPanel, DashboardShell } from "@/components/dashboard-shell"
 import { StatusBadge } from "@/components/status-badge"
 
@@ -18,12 +19,7 @@ type ExamRow = {
   lecturer_name?: string | null
 }
 
-function formatDateTime(value?: string | null) {
-  if (!value) return "TBD"
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) return "TBD"
-  return date.toLocaleString()
-}
+const formatDateTime = formatDateTimeEAT
 
 export default function AdminExamsPage() {
   const router = useRouter()

--- a/frontend/app/admin/system-logs/page.tsx
+++ b/frontend/app/admin/system-logs/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react"
 import { useRouter } from "next/navigation"
 import { LogOut } from "lucide-react"
 import { getApiPath } from "@/lib/api-url"
+import { formatDateTimeEATCompact } from "@/lib/format-time"
 import { DashboardPanel, DashboardShell } from "@/components/dashboard-shell"
 import { StatusBadge } from "@/components/status-badge"
 
@@ -33,16 +34,7 @@ type SessionRow = {
 
 const PAGE_SIZE_OPTIONS = [10, 25, 50]
 
-function formatDateTime(value?: string | null) {
-  if (!value) return "-"
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) return "-"
-  const day = String(date.getDate()).padStart(2, "0")
-  const month = String(date.getMonth() + 1).padStart(2, "0")
-  const year = date.getFullYear()
-  const time = date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: false })
-  return `${day}/${month}/${year} | ${time}`
-}
+const formatDateTime = formatDateTimeEATCompact
 
 function humanizeAction(action: string) {
   const clean = (action || "unknown").replace(/[._]+/g, " ").trim()

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useState } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import { BookOpenCheck, ClipboardList, Eye, EyeOff, LogOut, UserCircle2 } from "lucide-react"
 import { getApiPath } from "@/lib/api-url"
+import { formatDateTimeEAT } from "@/lib/format-time"
 import { DashboardPanel, DashboardShell, MetricCard } from "@/components/dashboard-shell"
 import { StatusBadge } from "@/components/status-badge"
 
@@ -97,12 +98,7 @@ const FALLBACK_DEGREE_PROGRAM_OPTIONS = [
   "Diploma in Information and Communication Technology (Dip. ICT)",
 ]
 
-function formatDateTime(value?: string | null) {
-  if (!value) return "TBD"
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) return "TBD"
-  return date.toLocaleString()
-}
+const formatDateTime = formatDateTimeEAT
 
 function StudentDashboardInner() {
   const router = useRouter()

--- a/frontend/app/exam/page.tsx
+++ b/frontend/app/exam/page.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils"
 import { useBrowserLockdown } from "@/hooks/use-browser-lockdown"
 import { Calculator } from "@/components/calculator"
 import { getApiPath, getSocketConnection } from "@/lib/api-url"
+import { formatDateEAT } from "@/lib/format-time"
 import { ThemeToggle } from "@/components/theme-toggle"
 
 type LiveQuestion = {
@@ -307,7 +308,7 @@ export default function ExamPage() {
         setTimeLeft(durationMin * 60)
         setExamDateLabel(
           payload.exam.scheduled_at
-            ? new Date(payload.exam.scheduled_at).toLocaleDateString()
+            ? formatDateEAT(payload.exam.scheduled_at)
             : "Scheduled session"
         )
         setQuestions(mapped)

--- a/frontend/app/lecturer/page.tsx
+++ b/frontend/app/lecturer/page.tsx
@@ -7,6 +7,7 @@ import Link from "next/link"
 import { io } from "socket.io-client"
 import { getApiPath, getSocketConnection } from "@/lib/api-url"
 import { cn } from "@/lib/utils"
+import { formatDateTimeEAT, formatTimeEAT } from "@/lib/format-time"
 import { DashboardPanel, DashboardShell, MetricCard } from "@/components/dashboard-shell"
 import { StatusBadge } from "@/components/status-badge"
 
@@ -135,12 +136,7 @@ const LECTURER_DEPARTMENT_OPTIONS = [
   "IST - Information System Technology",
 ]
 
-function formatDateTime(value?: string | null) {
-  if (!value) return "TBD"
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) return "TBD"
-  return date.toLocaleString()
-}
+const formatDateTime = formatDateTimeEAT
 
 function formatDateTimeInput(value?: string | null) {
   if (!value) return ""
@@ -1617,12 +1613,12 @@ function LecturerDashboardInner() {
             <table className="w-full text-xs">
               <thead className="sticky top-0 bg-muted/60">
                 <tr className="border-b text-left">
-                  <th className="py-2 pl-2">Time</th>
-                  <th>Student</th>
-                  <th>Exam</th>
-                  <th>Event</th>
-                  <th>Warnings</th>
-                  <th>Decision</th>
+                  <th className="py-2 pl-2 pr-3">Time</th>
+                  <th className="pr-3">Student</th>
+                  <th className="pr-3">Exam</th>
+                  <th className="w-1/4 pr-3">Event</th>
+                  <th className="pr-3">Warnings</th>
+                  <th className="pr-3">Decision</th>
                   <th className="pr-2">Action</th>
                 </tr>
               </thead>
@@ -1632,19 +1628,19 @@ function LecturerDashboardInner() {
                   const canTerminate = alertSession && ["active", "pending"].includes((alertSession.session_status || "").toLowerCase())
                   return (
                   <tr key={alert.log_id} className="border-b last:border-b-0">
-                    <td className="py-1.5 pl-2 whitespace-nowrap text-muted-foreground">
-                      {alert.logged_at ? new Date(alert.logged_at).toLocaleTimeString() : "—"}
+                    <td className="py-1.5 pl-2 pr-3 whitespace-nowrap text-muted-foreground">
+                      {formatTimeEAT(alert.logged_at)}
                     </td>
-                    <td className="whitespace-nowrap">{alert.student_name}</td>
-                    <td className="whitespace-nowrap">{alert.exam_title}</td>
-                    <td>
+                    <td className="whitespace-nowrap py-1.5 pr-3">{alert.student_name}</td>
+                    <td className="whitespace-nowrap py-1.5 pr-3">{alert.exam_title}</td>
+                    <td className="py-1.5 pr-3">
                       <span className="font-medium text-foreground">{formatEventLabel(alert.event_type)}</span>
                       {formatEventDetail(alert) && (
-                        <span className="block text-[11px] text-muted-foreground">{formatEventDetail(alert)}</span>
+                        <span className="mt-0.5 block text-[11px] leading-relaxed text-muted-foreground">{formatEventDetail(alert)}</span>
                       )}
                     </td>
-                    <td>{alert.warning_count}</td>
-                    <td>
+                    <td className="py-1.5 pr-3">{alert.warning_count}</td>
+                    <td className="py-1.5 pr-3">
                       {alert.is_suspicious === null || alert.is_suspicious === undefined ? (
                         <div className="flex gap-1">
                           <button
@@ -1668,7 +1664,7 @@ function LecturerDashboardInner() {
                         </span>
                       )}
                     </td>
-                    <td className="pr-2">
+                    <td className="py-1.5 pr-2">
                       {canTerminate && alertSession ? (
                         <div className="flex gap-1">
                           <button
@@ -2034,10 +2030,10 @@ function LecturerDashboardInner() {
             <table className="w-full text-xs">
               <thead className="sticky top-0 bg-muted/60">
                 <tr className="border-b text-left">
-                  <th className="py-2 pl-2">Time</th>
-                  <th>Event</th>
-                  <th>Detail</th>
-                  <th>Decision</th>
+                  <th className="py-2 pl-2 pr-3">Time</th>
+                  <th className="pr-3">Event</th>
+                  <th className="w-2/5 pr-3">Detail</th>
+                  <th className="pr-3">Decision</th>
                   <th className="pr-2">Action</th>
                 </tr>
               </thead>
@@ -2061,12 +2057,12 @@ function LecturerDashboardInner() {
                   }
                   return (
                   <tr key={log.log_id} className="border-b last:border-b-0">
-                    <td className="py-1.5 pl-2 whitespace-nowrap text-muted-foreground">
-                      {log.logged_at ? new Date(log.logged_at).toLocaleTimeString() : "—"}
+                    <td className="py-1.5 pl-2 pr-3 whitespace-nowrap text-muted-foreground">
+                      {formatTimeEAT(log.logged_at)}
                     </td>
-                    <td className="whitespace-nowrap font-medium text-foreground">{formatEventLabel(log.event_type)}</td>
-                    <td className="text-muted-foreground">{formatEventDetail(log)}</td>
-                    <td>
+                    <td className="whitespace-nowrap py-1.5 pr-3 font-medium text-foreground">{formatEventLabel(log.event_type)}</td>
+                    <td className="py-1.5 pr-3 leading-relaxed text-muted-foreground">{formatEventDetail(log)}</td>
+                    <td className="py-1.5 pr-3">
                       {log.is_suspicious === null || log.is_suspicious === undefined ? (
                         <div className="flex gap-1">
                           <button
@@ -2090,7 +2086,7 @@ function LecturerDashboardInner() {
                         </span>
                       )}
                     </td>
-                    <td className="pr-2">
+                    <td className="py-1.5 pr-2">
                       {canTerminate ? (
                         <div className="flex gap-1">
                           <button

--- a/frontend/lib/format-time.ts
+++ b/frontend/lib/format-time.ts
@@ -1,0 +1,50 @@
+// This system (University of Dodoma) only ever cares about East Africa Time,
+// regardless of which timezone a lecturer/admin/student's own browser or OS
+// happens to be set to. `toLocaleString()`/`toLocaleTimeString()` without an
+// explicit `timeZone` always render in the *viewer's* local timezone, no
+// matter what offset was embedded in the source timestamp - so a UTC or even
+// an already-EAT-converted string still displays wrong for anyone not
+// physically in EAT. Every date/time shown to a user must go through one of
+// these instead of a bare `new Date(...).toLocaleString()` call.
+const EAT_TIME_ZONE = "Africa/Nairobi"
+
+export function formatDateTimeEAT(value?: string | null, fallback = "TBD"): string {
+  if (!value) return fallback
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return fallback
+  return date.toLocaleString(undefined, { timeZone: EAT_TIME_ZONE })
+}
+
+export function formatDateEAT(value?: string | null, fallback = "TBD"): string {
+  if (!value) return fallback
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return fallback
+  return date.toLocaleDateString(undefined, { timeZone: EAT_TIME_ZONE })
+}
+
+export function formatTimeEAT(value?: string | null, fallback = "—"): string {
+  if (!value) return fallback
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return fallback
+  return date.toLocaleTimeString(undefined, { timeZone: EAT_TIME_ZONE })
+}
+
+// DD/MM/YYYY | HH:MM:SS (24h) - matches the admin system-logs table's
+// existing compact style, just pinned to EAT instead of browser-local.
+export function formatDateTimeEATCompact(value?: string | null, fallback = "-"): string {
+  if (!value) return fallback
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return fallback
+  const parts = new Intl.DateTimeFormat("en-GB", {
+    timeZone: EAT_TIME_ZONE,
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  }).formatToParts(date)
+  const get = (type: string) => parts.find((p) => p.type === type)?.value ?? ""
+  return `${get("day")}/${get("month")}/${get("year")} | ${get("hour")}:${get("minute")}:${get("second")}`
+}


### PR DESCRIPTION
## Summary

Two unrelated fixes bundled from the same testing session:

**1. Timestamps now always render in East Africa Time**, regardless of the viewer's own browser/OS timezone. `toLocaleString()`/`toLocaleTimeString()` without an explicit `timeZone` always render in the *viewer's* local timezone, no matter what offset was embedded in the source timestamp. Added one shared `frontend/lib/format-time.ts` and replaced every ad-hoc formatting call site (lecturer, student, admin, exam pages) with it. Found a real bug in passing: `admin/system-logs` already computed a `created_at_eat` field server-side, but the frontend discarded that conversion by re-parsing it with a bare `toLocaleTimeString()`.

**2. Fixed false "Identity Mismatch Detected" alerts caused by looking away or a turned head.** The periodic identity re-check ran on any frame with one detected face regardless of angle or detection confidence. FaceNet embeddings degrade badly under pose variation, so an off-angle or partially-occluded face crop produced a genuinely lower similarity score against the frontal baseline — misreported as an identity mismatch instead of the correct `gaze_away`/`head_turned` anomaly. Since the identity check's confirm cycle fires reliably fast (~8-16s) while gaze/head anomalies need their own separate persistence, the misleading alert reached the lecturer first and dominated. Now skips the identity check on frames where gaze is away, head is turned, or face-detection confidence is below `IDENTITY_CHECK_MIN_FACE_CONFIDENCE` (default 0.8).

## Test plan
- [x] Frontend `tsc --noEmit` clean
- [x] Full ai-service suite (54 passed, incl. 4 new tests: identity check skipped on gaze-away, skipped on head-turned, still runs on a normal frontal frame, skipped on low-confidence face detection)
- [x] Verified the EAT fix with a concrete before/after simulation (same UTC instant: 1:04 AM for a simulated New York viewer under old behavior vs correct 8:04 AM EAT under new)
- [ ] Manual click-through / live camera test by reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)