### PR TITLE
Fix anomaly confirmation window that could never actually confirm

### DIFF
--- a/ai-service/sockets/frame_handler.py
+++ b/ai-service/sockets/frame_handler.py
@@ -197,21 +197,35 @@ def _confirmed_anomalies(session_id, current_anomalies):
     underlying signal is consistently suspicious. Track recent evidence by
     base anomaly type instead of requiring the exact same direction to remain
     uninterrupted for the whole persistence window.
+
+    BUG FIXED (2026-08-04): this used to prune each anomaly_type's
+    observations down to `required_seconds` on EVERY call, including while
+    the anomaly was still actively happening every frame. That constantly
+    discarded the oldest evidence right before `persisted` (measured from
+    the oldest SURVIVING observation) was checked against that same
+    `required_seconds` - so persisted could only reach the threshold if two
+    consecutive frames landed on an exact timing coincidence, which never
+    happens with real frame arrival jitter (confirmed with a live
+    production log: 15s of continuous head_turned and 25s of continuous
+    face_absent, both never confirming once). The existing unit tests for
+    this function didn't catch it because they mock time.monotonic() with
+    idealized, exact-integer timestamps that happen to land precisely on
+    the pruning boundary - see test_frame_handler_debounce.py.
+
+    Fix: only drop an anomaly_type's tracking when it's genuinely absent
+    this frame (a real stop, not a rolling-window artifact), so
+    `observations[0]` stays the true start of the current streak and
+    `persisted` correctly measures its full duration.
     """
     now = time.monotonic()
     current = list(dict.fromkeys(current_anomalies))
+    current_types = {_base_type(a) for a in current}
 
     with _lock:
         session_state = _anomaly_states.setdefault(session_id, {})
 
-        for anomaly_type, state in list(session_state.items()):
-            required_seconds = _ANOMALY_SECONDS.get(anomaly_type, 3.0)
-            state['observations'] = [
-                observation
-                for observation in state['observations']
-                if now - observation[0] <= required_seconds
-            ]
-            if not state['observations'] and anomaly_type not in {_base_type(a) for a in current}:
+        for anomaly_type in list(session_state.keys()):
+            if anomaly_type not in current_types:
                 del session_state[anomaly_type]
 
         confirmed = []
@@ -225,7 +239,7 @@ def _confirmed_anomalies(session_id, current_anomalies):
 
             required_seconds = _ANOMALY_SECONDS.get(anomaly_type, 3.0)
             observations = state['observations']
-            persisted = now - observations[0][0] if observations else 0.0
+            persisted = now - observations[0][0]
             cooled_down = now - state['last_logged_at']
             enough_observations = len(observations) >= _ANOMALY_MIN_OBSERVATIONS
             if persisted >= required_seconds and enough_observations and cooled_down >= _WARNING_COOLDOWN_SECONDS:

--- a/ai-service/tests/test_frame_handler_debounce.py
+++ b/ai-service/tests/test_frame_handler_debounce.py
@@ -57,6 +57,50 @@ def test_rolling_window_recovers_after_anomaly_stops(monkeypatch):
     assert fh._confirmed_anomalies('s3', ['gaze_away:Right']) == []
 
 
+def test_sustained_anomaly_confirms_under_realistic_frame_jitter(monkeypatch):
+    """BUG (fixed 2026-08-04): _confirmed_anomalies used to prune each
+    anomaly_type's observations down to `required_seconds` on EVERY call,
+    including while the anomaly was still actively happening - which
+    constantly discarded the oldest evidence right before `persisted` was
+    checked against that same `required_seconds`, so confirmation was only
+    possible on an exact timing coincidence. The other tests in this file
+    mock time.monotonic() with idealized, exact-integer timestamps (0.0,
+    1.0, 2.0...) that happen to land precisely on that boundary and so
+    passed despite the bug - confirmed live in production (15s of
+    continuous head_turned, 25s of continuous face_absent, neither ever
+    confirming once). Real frame arrival is never that exact, so this uses
+    slightly-more-than-a-second gaps (matching observed production frame
+    spacing) to make sure a sustained anomaly still confirms under
+    realistic conditions, not just idealized mock timing."""
+    _reset_state()
+    # 1.01s-ish gaps, not exactly 1.0 - this is what actually broke it.
+    times = iter([0.0, 1.012, 2.019, 3.031, 4.038])
+    monkeypatch.setattr(fh.time, 'monotonic', lambda: next(times))
+
+    assert fh._confirmed_anomalies('jitter1', ['head_turned']) == []
+    assert fh._confirmed_anomalies('jitter1', ['head_turned']) == []
+    assert fh._confirmed_anomalies('jitter1', ['head_turned']) == ['head_turned']
+    assert fh._confirmed_anomalies('jitter1', ['head_turned']) == []
+    assert fh._confirmed_anomalies('jitter1', ['head_turned']) == []
+
+
+def test_long_sustained_anomaly_reconfirms_on_cooldown_under_jitter(monkeypatch):
+    """A student who never stops the violation (e.g. permanently turned
+    away) must keep re-triggering roughly every WARNING_COOLDOWN_SECONDS,
+    not just once at the start and then silently forever after - this is
+    the exact 15-second-sustained scenario observed live in production."""
+    _reset_state()
+    # ~1.01s apart for 15 "frames", matching real production frame spacing.
+    times = iter([round(i * 1.01, 3) for i in range(15)])
+    monkeypatch.setattr(fh.time, 'monotonic', lambda: next(times))
+
+    results = [fh._confirmed_anomalies('jitter2', ['face_absent']) for _ in range(15)]
+    confirmations = [r for r in results if r]
+
+    assert len(confirmations) >= 2  # at least the initial confirm plus one cooldown re-fire
+    assert all(r == ['face_absent'] for r in confirmations)
+
+
 def test_confirmed_anomaly_respects_cooldown(monkeypatch):
     _reset_state()
     times = iter([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0])


### PR DESCRIPTION
## Summary

Root cause of gaze_away/head_turned/face_absent/multiple_faces never firing, diagnosed directly from production logs pasted by the reporter.

`_confirmed_anomalies()` pruned each anomaly type's observation window down to `required_seconds` on **every** call, including while the anomaly was still actively happening every frame. That constantly discarded the oldest evidence right before `persisted` (measured from the oldest *surviving* observation) was checked against that same `required_seconds` — so `persisted` could only reach the threshold on an exact timing coincidence that never happens with real frame arrival jitter.

Confirmed with real production logs: 15 straight seconds of `raw_anomalies=['head_turned']` and 25 straight seconds of `raw_anomalies=['face_absent']`, both showing `confirmed=[]` on literally every frame. Reproduced precisely offline with real 1-second-spaced calls, and again against the pre-fix code using the new tests' realistic timing.

The existing unit tests for this function passed anyway — they mock `time.monotonic()` with idealized, exact-integer timestamps (`0.0, 1.0, 2.0...`) that happen to land exactly on the pruning boundary. Real frame timing is never that precise.

**Fix**: only clear an anomaly type's tracked evidence when it's genuinely absent that frame (a real stop), never while it's still actively happening, so `observations[0]` stays the true start of the current streak and `persisted` measures it correctly.

## Test plan
- [x] Full ai-service suite (56 passed, incl. 2 new regression tests using realistic jittery timing — proven to fail against the pre-fix code, unlike the existing exact-integer-timed tests — plus the specific 15-frame sustained scenario from the production log)
- [x] Verified live: a sustained anomaly now confirms at ~2s and re-fires every ~5s cooldown while it continues, matching the originally intended escalation pattern
- [ ] Manual live-camera test by reviewer (sustained look-away / face-covering / head-turn should now flag correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)